### PR TITLE
Add inspect element to menu if isDev - fixes #1

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 const electron = require('electron');
 const {download} = require('electron-dl');
+const isDev = require('electron-is-dev');
 
 function create(win, opts) {
 	win.webContents.on('context-menu', (e, props) => {
@@ -64,6 +65,19 @@ function create(win, opts) {
 
 		if (opts.append) {
 			menuTpl.push(...opts.append());
+		}
+
+		if (isDev) {
+			menuTpl.push({
+				type: 'separator'
+			}, {
+				label: 'Inspect Element',
+				click(item, win) {
+					win.inspectElement(props.x, props.y);
+				}
+			}, {
+				type: 'separator'
+			});
 		}
 
 		// filter out leading/trailing separators

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "image"
   ],
   "dependencies": {
-    "electron-dl": "^1.2.0"
+    "electron-dl": "^1.2.0",
+    "electron-is-dev": "^0.1.1"
   },
   "devDependencies": {
     "electron-prebuilt": "^1.2.1",

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 
 <img src="screenshot.png" width="125" align="right">
 
-Electron doesn't have a built-in context menu. You're supposed to handle that yourself. But it's both tedious and hard to get right. This module gives you a nice extensible context menu with items like `Cut`/`Copy`/`Paste` for text, `Save Image` for images, and `Copy Link` for links.
+Electron doesn't have a built-in context menu. You're supposed to handle that yourself. But it's both tedious and hard to get right. This module gives you a nice extensible context menu with items like `Cut`/`Copy`/`Paste` for text, `Save Image` for images, and `Copy Link` for links. It also adds an `Inspect Element` menu item when in `development` to quickly view items in the inspector like in Google Chrome.
 
 You can use this module directly in both the main and renderer process.
 


### PR DESCRIPTION
This adds an "Inspect Element" item to the end of the menu if the app is in `development`, which opens the web inspector and focuses it on the element under the mouse when the menu is opened. Basically like how Chrome works.

The only reason I added the `electron` package is because I'm getting a `xo` error without it. I don't mind removing it, but I think I'd have to add a comment to ignore the `require` line in `index.js`. Could be wrong, feel free to let me know.

This fixes #1.