### PR TITLE
Add "params" object on prepend and append methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,11 +60,11 @@ function create(win, opts) {
 		}
 
 		if (opts.prepend) {
-			menuTpl.unshift(...opts.prepend());
+			menuTpl.unshift(...opts.prepend(props));
 		}
 
 		if (opts.append) {
-			menuTpl.push(...opts.append());
+			menuTpl.push(...opts.append(props));
 		}
 
 		if (isDev) {


### PR DESCRIPTION
It is a simple fix to add "params" object on prepend and append methods to follow README example.

It allows to get all values from params object. 
Doc here : http://electron.atom.io/docs/api/web-contents/#event-context-menu 
