### PR TITLE
Add a `showInspectElement` option to allow manually toggling Inspect Element

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,8 +69,8 @@ function create(win, opts) {
 		if (opts.append) {
 			menuTpl.push(...opts.append(props));
 		}
-
-		if (opts.showInspectElement || isDev) {
+		
+		if (opts.showInspectElement || opts.showInspectElement !== false && isDev) {
 			menuTpl.push({
 				type: 'separator'
 			}, {

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ function create(win, opts) {
 			menuTpl.push(...opts.append(props));
 		}
 
-		if (isDev) {
+		if (opts.forceInspectElement || isDev) {
 			menuTpl.push({
 				type: 'separator'
 			}, {

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ function create(win, opts) {
 			menuTpl.push(...opts.append(props));
 		}
 
-		if (opts.forceInspectElement || isDev) {
+		if (opts.showInspectElement || isDev) {
 			menuTpl.push({
 				type: 'separator'
 			}, {

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ function create(win, opts) {
 		if (opts.append) {
 			menuTpl.push(...opts.append(props));
 		}
-		
+
 		if (opts.showInspectElement || opts.showInspectElement !== false && isDev) {
 			menuTpl.push({
 				type: 'separator'

--- a/index.js
+++ b/index.js
@@ -76,7 +76,10 @@ function create(win, opts) {
 			}, {
 				label: 'Inspect Element',
 				click(item, win) {
-					win.inspectElement(props.x, props.y);
+					win.webContents.inspectElement(props.x, props.y);
+					if (win.webContents.isDevToolsOpened()) {
+						win.webContents.devToolsWebContents.focus();
+					}
 				}
 			}, {
 				type: 'separator'

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ function create(win, opts) {
 			menuTpl.push(...opts.append(props));
 		}
 
-		if (opts.showInspectElement || opts.showInspectElement !== false && isDev) {
+		if (opts.showInspectElement || (opts.showInspectElement !== false && isDev)) {
 			menuTpl.push({
 				type: 'separator'
 			}, {

--- a/readme.md
+++ b/readme.md
@@ -63,11 +63,13 @@ Type: `Function`
 
 Should return an array of [MenuItem](http://electron.atom.io/docs/api/menu-item/)'s to be appended to the context menu. The first argument is [this `params` object](http://electron.atom.io/docs/api/web-contents/#event-context-menu).
 
-#### forceInspectElement
+#### showInspectElement
 
 Type: `Boolean`
 
-Enable the `Inspect Element` menu item all the time.
+Default: [Only in development](https://github.com/sindresorhus/electron-is-dev)
+
+Enable the `Inspect Element` menu item.
 
 
 ## Related

--- a/readme.md
+++ b/readme.md
@@ -63,6 +63,12 @@ Type: `Function`
 
 Should return an array of [MenuItem](http://electron.atom.io/docs/api/menu-item/)'s to be appended to the context menu. The first argument is [this `params` object](http://electron.atom.io/docs/api/web-contents/#event-context-menu).
 
+#### forceInspectElement
+
+Type: `Boolean`
+
+Enable the `Inspect Element` menu item all the time.
+
 
 ## Related
 


### PR DESCRIPTION
Our electron app is a wrapper for our web app, and our users are accustomed to having access to the browser inspector, to test out custom user styles/scripts.