### PR TITLE
Delete unnecessary separators and don't show menu when there are no visible items

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,26 +89,22 @@ function create(win, opts) {
 
 		// filter out leading/trailing separators
 		// TODO: https://github.com/electron/electron/issues/5869
-		menuTpl = deleteUnnecessarySeparatorsAndElements(menuTpl);
+		menuTpl = delUnusedElements(menuTpl);
 
-		if (menuTpl.some(elem => isVisible(elem))) {
+		if (menuTpl.length > 0) {
 			const menu = (electron.Menu || electron.remote.Menu).buildFromTemplate(menuTpl);
 			menu.popup(win);
 		}
 	});
 }
 
-function deleteUnnecessarySeparatorsAndElements(menuTpl) {
-	let visiblePreviousEl;
-	return menuTpl.filter(el => isVisible(el)).filter((el, i, arr) => {
-		const toDelete = el.type === 'separator' && (!visiblePreviousEl || i === arr.length - 1 || arr[i + 1].type === 'separator');
-		visiblePreviousEl = toDelete || !isVisible(el) ? visiblePreviousEl : el;
+function delUnusedElements(menuTpl) {
+	let notDeletedPrevEl;
+	return menuTpl.filter(el => el.visible !== false).filter((el, i, arr) => {
+		const toDelete = el.type === 'separator' && (!notDeletedPrevEl || i === arr.length - 1 || arr[i + 1].type === 'separator');
+		notDeletedPrevEl = toDelete ? notDeletedPrevEl : el;
 		return !toDelete;
 	});
-}
-
-function isVisible(elem) {
-	return !('visible' in elem) || elem.visible;
 }
 
 module.exports = (opts = {}) => {

--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ function create(win, opts) {
 
 function deleteUnnecessarySeparatorsAndElements(menuTpl) {
 	let visiblePreviousEl;
-	return menuTpl.filter((el, i, arr) => isVisible(el)).filter((el, i, arr) => {
+	return menuTpl.filter((el) => isVisible(el)).filter((el, i, arr) => {
 		const toDelete = el.type === 'separator' && (!visiblePreviousEl || i === arr.length - 1 || arr[i + 1].type === 'separator');
 		visiblePreviousEl = toDelete || !isVisible(el) ? visiblePreviousEl : el;
 		return !toDelete;

--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ function create(win, opts) {
 function deleteUnnecessarySeparators(menuTpl) {
 	let visiblePreviousEl;
 	return menuTpl.filter((el, i, arr) => {
-		var toDelete = el.type === 'separator' && (!visiblePreviousEl || i === arr.length - 1 || arr[i + 1].type === 'separator');
+		let toDelete = el.type === 'separator' && (!visiblePreviousEl || i === arr.length - 1 || arr[i + 1].type === 'separator');
 		visiblePreviousEl = toDelete || !isVisible(el) ? visiblePreviousEl : el;
 		return !toDelete;
 	});

--- a/index.js
+++ b/index.js
@@ -89,11 +89,26 @@ function create(win, opts) {
 
 		// filter out leading/trailing separators
 		// TODO: https://github.com/electron/electron/issues/5869
-		menuTpl = menuTpl.filter((el, i, arr) => !(el.type === 'separator' && (i === 0 || i === arr.length - 1 || arr[i + 1].type === 'separator')));
+		menuTpl = deleteUnnecessarySeparators(menuTpl);
 
-		const menu = (electron.Menu || electron.remote.Menu).buildFromTemplate(menuTpl);
-		menu.popup(win);
+		if (menuTpl.some(elem => isVisible(elem))) {
+			const menu = (electron.Menu || electron.remote.Menu).buildFromTemplate(menuTpl);
+			menu.popup(win);
+		}
 	});
+}
+
+function deleteUnnecessarySeparators(menuTpl) {
+	let visiblePreviousEl;
+	return menuTpl.filter((el, i, arr) => {
+		var toDelete = el.type === 'separator' && (!visiblePreviousEl || i === arr.length - 1 || arr[i + 1].type === 'separator');
+		visiblePreviousEl = toDelete || !isVisible(el) ? visiblePreviousEl : el;
+		return !toDelete;
+	});
+}
+
+function isVisible(elem) {
+	return !('visible' in elem) || elem.visible;
 }
 
 module.exports = (opts = {}) => {

--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ function create(win, opts) {
 
 function deleteUnnecessarySeparatorsAndElements(menuTpl) {
 	let visiblePreviousEl;
-	return menuTpl.filter((el) => isVisible(el)).filter((el, i, arr) => {
+	return menuTpl.filter(el => isVisible(el)).filter((el, i, arr) => {
 		const toDelete = el.type === 'separator' && (!visiblePreviousEl || i === arr.length - 1 || arr[i + 1].type === 'separator');
 		visiblePreviousEl = toDelete || !isVisible(el) ? visiblePreviousEl : el;
 		return !toDelete;

--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ function create(win, opts) {
 
 		// filter out leading/trailing separators
 		// TODO: https://github.com/electron/electron/issues/5869
-		menuTpl = deleteUnnecessarySeparators(menuTpl);
+		menuTpl = deleteUnnecessarySeparatorsAndElements(menuTpl);
 
 		if (menuTpl.some(elem => isVisible(elem))) {
 			const menu = (electron.Menu || electron.remote.Menu).buildFromTemplate(menuTpl);
@@ -98,9 +98,9 @@ function create(win, opts) {
 	});
 }
 
-function deleteUnnecessarySeparators(menuTpl) {
+function deleteUnnecessarySeparatorsAndElements(menuTpl) {
 	let visiblePreviousEl;
-	return menuTpl.filter((el, i, arr) => {
+	return menuTpl.filter((el, i, arr) => isVisible(el)).filter((el, i, arr) => {
 		const toDelete = el.type === 'separator' && (!visiblePreviousEl || i === arr.length - 1 || arr[i + 1].type === 'separator');
 		visiblePreviousEl = toDelete || !isVisible(el) ? visiblePreviousEl : el;
 		return !toDelete;

--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ function create(win, opts) {
 function deleteUnnecessarySeparators(menuTpl) {
 	let visiblePreviousEl;
 	return menuTpl.filter((el, i, arr) => {
-		let toDelete = el.type === 'separator' && (!visiblePreviousEl || i === arr.length - 1 || arr[i + 1].type === 'separator');
+		const toDelete = el.type === 'separator' && (!visiblePreviousEl || i === arr.length - 1 || arr[i + 1].type === 'separator');
 		visiblePreviousEl = toDelete || !isVisible(el) ? visiblePreviousEl : el;
 		return !toDelete;
 	});


### PR DESCRIPTION
Delete separators when previous elements are not visible and doesn't show menu when no visible elements are available.