### PR TITLE
Add webview support

### DIFF
--- a/fixture.html
+++ b/fixture.html
@@ -3,6 +3,14 @@
 	<head>
 		<meta charset="utf-8">
 		<title>Fixture</title>
+		<script>
+			window.addEventListener('load', () => {
+				const webview = document.getElementById('webview');
+				require('.')({
+					window: webview
+				});
+			});
+		</script>
 	</head>
 	<body>
 		<h1>Fixture</h1>
@@ -16,5 +24,6 @@
 		<div contenteditable="true"><strong>Editable text</strong></div>
 		<br>
 		<a href="https://github.com">Link</a>
+		<webview id="webview" src="http://example.org">
 	</body>
 </html>

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const {download} = require('electron-dl');
 const isDev = require('electron-is-dev');
 
 function create(win, opts) {
-	win.webContents.on('context-menu', (e, props) => {
+	(win.webContents || win.getWebContents()).on('context-menu', (e, props) => {
 		const editFlags = props.editFlags;
 		const hasText = props.selectionText.trim().length > 0;
 		const can = type => editFlags[`can${type}`] && hasText;
@@ -92,14 +92,33 @@ function create(win, opts) {
 		menuTpl = menuTpl.filter((el, i, arr) => !(el.type === 'separator' && (i === 0 || i === arr.length - 1 || arr[i + 1].type === 'separator')));
 
 		const menu = (electron.Menu || electron.remote.Menu).buildFromTemplate(menuTpl);
-		menu.popup(win);
+
+		/*
+		 * When electron.remote is not available this runs in the browser process.
+		 * We can safely use win in this case as it refers to the window the
+		 * context-menu should open in.
+		 * When this is being called from a webView, we can't use win as this
+		 * would refere to the webView which is not allowed to render a popup menu.
+		 */
+		menu.popup(electron.remote ? electron.remote.getCurrentWindow() : win);
 	});
 }
 
 module.exports = (opts = {}) => {
 	if (opts.window) {
-		create(opts.window, opts);
-		return;
+		const win = opts.window;
+		const webContents = win.webContents || win.getWebContents();
+
+		// When window is a webview that has not yet finished loading webContents is not available
+		if (webContents === undefined) {
+			win.addEventListener('dom-ready', () => {
+				create(win, opts);
+			}, {
+				once: true
+			});
+			return;
+		}
+		return create(win, opts);
 	}
 
 	(electron.BrowserWindow || electron.remote.BrowserWindow).getAllWindows().forEach(win => {

--- a/readme.md
+++ b/readme.md
@@ -45,9 +45,9 @@ app.on('ready', () => {
 
 #### window
 
-Type: `BrowserWindow`<br>
+Type: `BrowserWindow` `WebView`<br>
 
-Window to add the context menu to.
+Window or WebView to add the context menu to.
 
 When not specified, the context menu will be added to all existing and new windows.
 


### PR DESCRIPTION
Hey there,
I have been trying to get `electron-context-menu` to work in an environment with multiple WebViews.

Turns out the `context-menu` event does not propagate through the application when it gets fired in the webviews `webContents`.

I tried to attach the event handle manually by passing a window param to the create method, but `webView.webContents` does not exist, instead one has to use `webView.getWebContents()`.

Plus it's not possible to open the menu on a webview, so I changed menu.popup to use the currently focused window which makes sense, I guess.