### PR TITLE
Add option to allow context menu to show based on context

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,9 @@ const isDev = require('electron-is-dev');
 
 function create(win, opts) {
 	(win.webContents || win.getWebContents()).on('context-menu', (e, props) => {
+		if (typeof opts.shouldShowMenu === 'function' && opts.shouldShowMenu(e, props) === false) {
+			return;
+		}
 		const editFlags = props.editFlags;
 		const hasText = props.selectionText.trim().length > 0;
 		const can = type => editFlags[`can${type}`] && hasText;

--- a/readme.md
+++ b/readme.md
@@ -90,6 +90,19 @@ labels: {
 }
 ```
 
+#### shouldShowMenu
+
+Type: `Function`
+
+Determines whether or not to show the menu
+
+```js
+// disable menu if element is editable
+shouldShowMenu: function(event, props) {
+  return !props.isEditable;
+}
+```
+
 ## Related
 
 - [electron-debug](https://github.com/sindresorhus/electron-debug) - Adds useful debug features to your Electron app


### PR DESCRIPTION
Conditionally display context menu based on context of the element selected.

I ran into a collision with my other context menu that I was using for inputs: `electron-context-editor-menu`.  

This allows both of them to play nicely.