### PR TITLE
Added menu item for copying link of an image

### DIFF
--- a/fixture.js
+++ b/fixture.js
@@ -8,6 +8,7 @@ require('.')({
 		paste: 'Configured Paste',
 		save: 'Configured Save Image',
 		copyLink: 'Configured Copy Link',
+		copyImageLink: 'Configured Copy Image Link',
 		inspect: 'Configured Inspect'
 	},
 	prepend: () => [{
@@ -16,6 +17,9 @@ require('.')({
 		type: 'separator'
 	}, {
 		type: 'separator'
+	}, {
+		label: 'Invisible',
+		visible: false
 	}, {
 		label: 'Invisible',
 		visible: false

--- a/index.js
+++ b/index.js
@@ -52,7 +52,11 @@ function create(win, opts) {
 				id: 'copyImageLink',
 				label: 'Copy Image Link',
 				click() {
-					electron.clipboard.writeText(props.srcURL);
+					if (process.platform === 'darwin') {
+						electron.clipboard.writeBookmark(props.srcURL, props.srcURL);
+					} else {
+						electron.clipboard.writeText(props.srcURL);
+					}
 				}
 			}, {
 				type: 'separator'

--- a/index.js
+++ b/index.js
@@ -49,6 +49,12 @@ function create(win, opts) {
 					download(win, props.srcURL);
 				}
 			}, {
+				id: 'copyImageLink',
+				label: 'Copy Image Link',
+				click() {
+					electron.clipboard.writeText(props.srcURL);
+				}
+			}, {
 				type: 'separator'
 			}];
 		}

--- a/readme.md
+++ b/readme.md
@@ -86,6 +86,7 @@ labels: {
 	paste: 'Configured Paste',
 	save: 'Configured Save Image',
 	copyLink: 'Configured Copy Link',
+	copyImageLink: 'Configured Copy Image Link'
 	inspect: 'Configured Inspect'
 }
 ```

--- a/readme.md
+++ b/readme.md
@@ -86,7 +86,7 @@ labels: {
 	paste: 'Configured Paste',
 	save: 'Configured Save Image',
 	copyLink: 'Configured Copy Link',
-	copyImageLink: 'Configured Copy Image Link'
+	copyImageLink: 'Configured Copy Image Link',
 	inspect: 'Configured Inspect'
 }
 ```


### PR DESCRIPTION
Fixes #20 

Added one more item to the context-menu, that let's the user get the link (url src) of an image. It is only displayed when the user clicks on an image - its visibility is initially set to false.