### PR TITLE
Add `menu` option

### DIFF
--- a/fixture.js
+++ b/fixture.js
@@ -32,7 +32,7 @@ contextMenu({
 		},
 		actions.paste({transform: content => 'modified_paste_' + content})
 	],
-	append: actions => [actions.saveImage(), actions.saveImageAs()],
+	append: actions => [actions.saveImage(), actions.saveImageAs(), actions.copyImageAddress()],
 	showCopyImageAddress: true,
 	showSaveImageAs: true
 });

--- a/fixture.js
+++ b/fixture.js
@@ -32,7 +32,7 @@ contextMenu({
 		},
 		actions.paste({transform: content => 'modified_paste_' + content})
 	],
-	append: actions => [actions.saveImage(), actions.saveImageAs(), actions.copyImageAddress()],
+	append: actions => [actions.saveImage(), actions.saveImageAs(), actions.copyImageAddress(), actions.separator(), actions.inspect()],
 	showCopyImageAddress: true,
 	showSaveImageAs: true
 });

--- a/fixture.js
+++ b/fixture.js
@@ -10,23 +10,23 @@ require('.')({
 		copyLink: 'Configured Copy Link',
 		inspect: 'Configured Inspect'
 	},
-	prepend: (x) => [x.CUT({transform: (content) => "modified_cut_" + content})],
-	menu: (x) => [
-		x.SEPARATOR(),
-		x.COPY_LINK({transform: (content) => "modified_link_" + content}),
-		x.SEPARATOR(),
+	prepend: (actions) => [actions.cut({transform: (content) => "modified_cut_" + content})],
+	menu: (actions) => [
+		actions.separator(),
+		actions.copyLink({transform: (content) => "modified_link_" + content}),
+		actions.separator(),
 		{
 			label: 'Unicorn'
 		},
-		x.SEPARATOR(),
-		x.COPY({transform: (content) => "modified_copy_" + content}),
+		actions.separator(),
+		actions.copy({transform: (content) => "modified_copy_" + content}),
 		{
 			label: 'Invisible',
 			visible: false
 		},
-		x.PASTE({transform: (content) => "modified_paste_" + content})
+		actions.paste({transform: (content) => "modified_paste_" + content})
 	],
-	append: (x) => [x.SAVE_IMAGE()]
+	append: (actions) => [actions.saveImage()]
 });
 
 electron.app.on('ready', () => {

--- a/fixture.js
+++ b/fixture.js
@@ -10,21 +10,23 @@ require('.')({
 		copyLink: 'Configured Copy Link',
 		inspect: 'Configured Inspect'
 	},
-	prepend: () => [{
-		label: 'Unicorn'
-	}, {
-		type: 'separator'
-	}, {
-		type: 'separator'
-	}, {
-		label: 'Invisible',
-		visible: false
-	}, {
-		type: 'separator'
-	}, {
-		type: 'separator'
-	}],
-	append: () => {}
+	prepend: (x) => [x.CUT({transform: (content) => "modified_cut_" + content})],
+	menu: (x) => [
+		x.SEPARATOR(),
+		x.COPY_LINK({transform: (content) => "modified_link_" + content}),
+		x.SEPARATOR(),
+		{
+			label: 'Unicorn'
+		},
+		x.SEPARATOR(),
+		x.COPY({transform: (content) => "modified_copy_" + content}),
+		{
+			label: 'Invisible',
+			visible: false
+		},
+		x.PASTE({transform: (content) => "modified_paste_" + content})
+	],
+	append: (x) => [x.SAVE_IMAGE()]
 });
 
 electron.app.on('ready', () => {

--- a/index.d.ts
+++ b/index.d.ts
@@ -48,6 +48,24 @@ export interface Labels {
 	readonly inspect?: string;
 }
 
+export interface ActionOptions {
+	/**
+	 * Apply transformation function to the content of the action
+	 */
+	readonly transform?: (content: string) => string;
+}
+
+export interface Actions {
+	readonly separator: () => MenuItem;
+	readonly inspect: () => MenuItem;
+	readonly cut: (options: ActionOptions) => MenuItem;
+	readonly copy: (options: ActionOptions) => MenuItem;
+	readonly paste: (options: ActionOptions) => MenuItem;
+	readonly saveImage: (options: ActionOptions) => MenuItem;
+	readonly saveImageAs: (options: ActionOptions) => MenuItem;
+	readonly copyImageAddress: (options: ActionOptions) => MenuItem;
+}
+
 export interface Options {
 	/**
 	 * Window or WebView to add the context menu to.
@@ -58,12 +76,18 @@ export interface Options {
 	/**
 	 * Should return an array of [menu items](https://electronjs.org/docs/api/menu-item) to be prepended to the context menu.
 	 */
-	readonly prepend?: (params: ContextMenuParams, browserWindow: BrowserWindow | WebviewTag) => MenuItem[];
+	readonly prepend?: (defaultActions: Actions, params: ContextMenuParams, browserWindow: BrowserWindow | WebviewTag) => MenuItem[];
+
+	/**
+	 * Should return an array of [menu items](https://electronjs.org/docs/api/menu-item) to override the default context menu.
+	 * @default [defaultActions.cut(), defaultActions.copy(), defaultActions.paste(), defaultActions.separator(), defaultActions.saveImage(), defaultActions.saveImageAs(), defaultActions.copyImageAddress(), defaultActions.separator(), defaultActions.copyLink(), defaultActions.separator(), defaultActions.inspect()]
+	 */
+	readonly menu?: (defaultActions: Actions, params: ContextMenuParams, browserWindow: BrowserWindow | WebviewTag) => MenuItem[];
 
 	/**
 	 * Should return an array of [menu items](https://electronjs.org/docs/api/menu-item) to be appended to the context menu.
 	 */
-	readonly append?: (param: ContextMenuParams, browserWindow: BrowserWindow | WebviewTag) => MenuItem[];
+	readonly append?: (defaultActions: Actions, param: ContextMenuParams, browserWindow: BrowserWindow | WebviewTag) => MenuItem[];
 
 	/**
 	 * Show the `Copy Image Address` menu item when right-clicking on an image.

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ function create(win, opts) {
 			INSPECT: decorateMenuItem({
 				id: 'inspect',
 				label: 'Inspect Element',
-				click(menuItem) {
+				click() {
 					win.inspectElement(props.x, props.y);
 
 					if (webContents(win).isDevToolsOpened()) {
@@ -93,7 +93,6 @@ function create(win, opts) {
 			COPY_LINK: decorateMenuItem({
 				id: 'copyLink',
 				label: 'Copy Link',
-				// visible: props.linkURL && props.mediaType === 'none',
 				visible: props.linkURL.length !== 0 && props.mediaType === 'none',
 				click(menuItem) {
 					props.linkURL = menuItem.transform ? menuItem.transform(props.linkURL) : props.linkURL;
@@ -105,9 +104,9 @@ function create(win, opts) {
 					}
 				}
 			})
-		}
+		};
 
-		const defaultMenu = [defaultActions.SEPARATOR(), defaultActions.CUT(), defaultActions.COPY(), defaultActions.PASTE(), defaultActions.SEPARATOR()]
+		const defaultMenu = [defaultActions.SEPARATOR(), defaultActions.CUT(), defaultActions.COPY(), defaultActions.PASTE(), defaultActions.SEPARATOR()];
 
 		let menuTpl = defaultMenu;
 
@@ -173,16 +172,16 @@ function create(win, opts) {
 
 function decorateMenuItem(menuItem) {
 	return (opts = {}) => {
-		if(opts.transform && !opts.click){
+		if (opts.transform && !opts.click) {
 			menuItem.transform = opts.transform;
 		}
 
-		if(opts.click) {
+		if (opts.click) {
 			menuItem.click = opts.click;
 		}
 
 		return menuItem;
-	}
+	};
 }
 
 function delUnusedElements(menuTpl) {

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function create(win, opts) {
 		const can = type => editFlags[`can${type}`] && hasText;
 
 		const defaultActions = {
-			CUT: decorateMenuItem({
+			cut: decorateMenuItem({
 				id: 'cut',
 				label: 'Cut',
 				enabled: can('Cut'),
@@ -33,7 +33,7 @@ function create(win, opts) {
 					win.webContents.delete();
 				}
 			}),
-			COPY: decorateMenuItem({
+			copy: decorateMenuItem({
 				id: 'copy',
 				label: 'Copy',
 				enabled: can('Copy'),
@@ -48,7 +48,7 @@ function create(win, opts) {
 					}
 				}
 			}),
-			PASTE: decorateMenuItem({
+			paste: decorateMenuItem({
 				id: 'paste',
 				label: 'Paste',
 				enabled: editFlags.canPaste,
@@ -67,7 +67,7 @@ function create(win, opts) {
 				}
 
 			}),
-			INSPECT: decorateMenuItem({
+			inspect: decorateMenuItem({
 				id: 'inspect',
 				label: 'Inspect Element',
 				click() {
@@ -78,10 +78,10 @@ function create(win, opts) {
 					}
 				}
 			}),
-			SEPARATOR: decorateMenuItem({
+			separator: decorateMenuItem({
 				type: 'separator'
 			}),
-			SAVE_IMAGE: decorateMenuItem({
+			saveImage: decorateMenuItem({
 				id: 'save',
 				label: 'Save Image',
 				visible: props.mediaType === 'image',
@@ -90,7 +90,7 @@ function create(win, opts) {
 					download(win, props.srcURL);
 				}
 			}),
-			COPY_LINK: decorateMenuItem({
+			copyLink: decorateMenuItem({
 				id: 'copyLink',
 				label: 'Copy Link',
 				visible: props.linkURL.length !== 0 && props.mediaType === 'none',
@@ -106,20 +106,20 @@ function create(win, opts) {
 			})
 		};
 
-		const defaultMenu = [defaultActions.SEPARATOR(), defaultActions.CUT(), defaultActions.COPY(), defaultActions.PASTE(), defaultActions.SEPARATOR()];
-
-		let menuTpl = defaultMenu;
+		let menuTpl = [
+			defaultActions.separator(),
+			defaultActions.cut(),
+			defaultActions.copy(),
+			defaultActions.paste(),
+			defaultActions.separator(),
+			defaultActions.saveImage(),
+			defaultActions.separator(),
+			defaultActions.copyLink(),
+			defaultActions.separator()
+		];
 
 		if (opts.menu) {
 			menuTpl = opts.menu(defaultActions, props, win);
-		}
-
-		if (!opts.menu && props.mediaType === 'image') {
-			menuTpl = [defaultActions.SEPARATOR(), defaultActions.SAVE_IMAGE(), defaultActions.SEPARATOR()];
-		}
-
-		if (!opts.menu && props.linkURL && props.mediaType === 'none') {
-			menuTpl = [defaultActions.SEPARATOR(), defaultActions.COPY_LINK(), defaultActions.SEPARATOR()];
 		}
 
 		if (opts.prepend) {
@@ -139,7 +139,7 @@ function create(win, opts) {
 		}
 
 		if (opts.showInspectElement || (opts.showInspectElement !== false && isDev)) {
-			menuTpl.push(defaultActions.SEPARATOR(), defaultActions.INSPECT(), defaultActions.SEPARATOR());
+			menuTpl.push(defaultActions.separator(), defaultActions.inspect(), defaultActions.separator());
 		}
 
 		// Apply custom labels for default menu items
@@ -174,10 +174,6 @@ function decorateMenuItem(menuItem) {
 	return (opts = {}) => {
 		if (opts.transform && !opts.click) {
 			menuItem.transform = opts.transform;
-		}
-
-		if (opts.click) {
-			menuItem.click = opts.click;
 		}
 
 		return menuItem;

--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ function create(win, options) {
 			saveImageAs: decorateMenuItem({
 				id: 'saveImageAs',
 				label: 'Save Image As…',
-				visible: props.mediaType === 'image',
+				visible: options.showSaveImageAs && props.mediaType === 'image',
 				click(menuItem) {
 					props.srcURL = menuItem.transform ? menuItem.transform(props.srcURL) : props.srcURL;
 					download(win, props.srcURL, {saveAs: true});
@@ -96,7 +96,7 @@ function create(win, options) {
 			copyImageAddress: decorateMenuItem({
 				id: 'copyImageAddress',
 				label: 'Copy Image Address',
-				visible: props.srcURL.length !== 0 && props.mediaType === 'image',
+				visible: options.showCopyImageAddress && props.mediaType === 'image',
 				click(menuItem) {
 					props.srcURL = menuItem.transform ? menuItem.transform(props.srcURL) : props.srcURL;
 

--- a/index.js
+++ b/index.js
@@ -23,12 +23,7 @@ function create(win, options) {
 				visible: props.isEditable,
 				click(menuItem) {
 					props.selectionText = menuItem.transform ? menuItem.transform(props.selectionText) : props.selectionText;
-
-					electron.clipboard.write({
-						bookmark: props.linkText,
-						text: props.linkUrl
-					});
-
+					electron.clipboard.writeText(props.selectionText);
 					win.webContents.delete();
 				}
 			}),
@@ -39,11 +34,7 @@ function create(win, options) {
 				visible: props.isEditable || hasText,
 				click(menuItem) {
 					props.selectionText = menuItem.transform ? menuItem.transform(props.selectionText) : props.selectionText;
-
-					electron.clipboard.write({
-						bookmark: props.linkText,
-						text: props.linkUrl
-					});
+					electron.clipboard.writeText(props.selectionText);
 				}
 			}),
 			paste: decorateMenuItem({
@@ -52,16 +43,8 @@ function create(win, options) {
 				enabled: editFlags.canPaste,
 				visible: props.isEditable,
 				click(menuItem) {
-					let clipboardContent;
-					if (process.platform === 'darwin') {
-						clipboardContent = electron.clipboard.readBookmark();
-					} else {
-						clipboardContent = electron.clipboard.readText(props.selectionText);
-					}
-
-
+					let clipboardContent = electron.clipboard.readText(props.selectionText);
 					clipboardContent = menuItem.transform ? menuItem.transform(clipboardContent) : clipboardContent;
-
 					win.webContents.insertText(clipboardContent);
 				}
 			}),

--- a/index.js
+++ b/index.js
@@ -48,20 +48,25 @@ function create(win, options) {
 					win.webContents.insertText(clipboardContent);
 				}
 			}),
-			inspect: decorateMenuItem({
-				id: 'inspect',
-				label: 'Inspect Element',
-				click() {
-					win.inspectElement(props.x, props.y);
+			inspect: () => {
+				return {
+					id: 'inspect',
+					label: 'Inspect Element',
+					enabled: options.showInspectElement || (options.showInspectElement !== false && isDev),
+					click() {
+						win.inspectElement(props.x, props.y);
 
-					if (webContents(win).isDevToolsOpened()) {
-						webContents(win).devToolsWebContents.focus();
+						if (webContents(win).isDevToolsOpened()) {
+							webContents(win).devToolsWebContents.focus();
+						}
 					}
-				}
-			}),
-			separator: decorateMenuItem({
-				type: 'separator'
-			}),
+				};
+			},
+			separator: () => {
+				return {
+					type: 'separator'
+				};
+			},
 			saveImage: decorateMenuItem({
 				id: 'save',
 				label: 'Save Image',
@@ -119,6 +124,8 @@ function create(win, options) {
 			defaultActions.copyImageAddress(),
 			defaultActions.separator(),
 			defaultActions.copyLink(),
+			defaultActions.separator(),
+			defaultActions.inspect(),
 			defaultActions.separator()
 		];
 
@@ -140,10 +147,6 @@ function create(win, options) {
 			if (Array.isArray(result)) {
 				menuTpl.push(...result);
 			}
-		}
-
-		if (options.showInspectElement || (options.showInspectElement !== false && isDev)) {
-			menuTpl.push(defaultActions.separator(), defaultActions.inspect(), defaultActions.separator());
 		}
 
 		// Apply custom labels for default menu items

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-context-menu",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Context menu for your Electron app",
   "license": "MIT",
   "repository": "sindresorhus/electron-context-menu",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,13 @@
     "envs": [
       "node",
       "browser"
-    ]
+    ],
+    "rules": {
+      "new-cap": ["error", {
+          "newIsCap": true,
+          "capIsNew": true,
+          "properties": false
+      }]
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,13 +39,6 @@
     "envs": [
       "node",
       "browser"
-    ],
-    "rules": {
-      "new-cap": ["error", {
-          "newIsCap": true,
-          "capIsNew": true,
-          "properties": false
-      }]
-    }
+    ]
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -63,17 +63,18 @@ When not specified, the context menu will be added to all existing and new windo
 #### menu
 Type: `Function`
 
-Should return an array of [MenuItem](https://electronjs.org/docs/api/menu-item/)'s to be shown in the context menu. The first argument is an array of default actions that can be used. These actions are functions that can take an object with a transform property. The transform function will get the content of what will be copied and can modify it if needed. If no menu property is defined, the default menu will be used.
+Should return an array of [MenuItem](https://electronjs.org/docs/api/menu-item/)'s to be shown in the context menu. The first argument is an array of default actions that can be used. These actions are functions that can take an object with a transform property. The transform function will be passed the content of the action and can modify it if needed. If no menu property is defined, the default menu will be used.
 
 Default actions:
 - `cut`
 - `copy`
 - `paste`
-- `cut`
 - `inspect`
 - `separator`
 - `saveImage`
+- `saveImageAs`
 - `copyLink`
+- `copyImageAddress`
 
 ```js
 menu: (actions) => [

--- a/readme.md
+++ b/readme.md
@@ -51,17 +51,50 @@ Window or WebView to add the context menu to.
 
 When not specified, the context menu will be added to all existing and new windows.
 
+#### menu
+Type: `Function`
+
+Should return an array of [MenuItem](http://electron.atom.io/docs/api/menu-item/)'s to be shown in the context menu. The first argument is an array of default actions that can be used. These actions are functions that can take an object with a transform property. The transform function will get the content of what will be copied and can modify it if needed. If no menu property is defined, the default menu will be used.
+
+Default actions:
+- `cut`
+- `copy`
+- `paste`
+- `cut`
+- `inspect`
+- `separator`
+- `saveImage`
+- `copyLink`
+
+```js
+menu: (actions) => [
+	actions.separator(),
+	actions.copyLink({transform: (content) => "modified_link_" + content}),
+	actions.separator(),
+	{
+		label: 'Unicorn'
+	},
+	actions.separator(),
+	actions.copy({transform: (content) => "modified_copy_" + content}),
+	{
+		label: 'Invisible',
+		visible: false
+	},
+	actions.paste({transform: (content) => "modified_paste_" + content})
+	]
+```
+
 #### prepend
 
 Type: `Function`
 
-Should return an array of [MenuItem](http://electron.atom.io/docs/api/menu-item/)'s to be prepended to the context menu. The first argument is [this `params` object](http://electron.atom.io/docs/api/web-contents/#event-context-menu). The second argument is the [BrowserWindow](http://electron.atom.io/docs/api/browser-window/) the context menu was requested for.
+Should return an array of [MenuItem](http://electron.atom.io/docs/api/menu-item/)'s to be prepended to the context menu. The first argument is an array of default actions that can be used. The first argument is [this `params` object](http://electron.atom.io/docs/api/web-contents/#event-context-menu). The second argument is the [BrowserWindow](http://electron.atom.io/docs/api/browser-window/) the context menu was requested for.
 
 #### append
 
 Type: `Function`
 
-Should return an array of [MenuItem](http://electron.atom.io/docs/api/menu-item/)'s to be appended to the context menu. The first argument is [this `params` object](http://electron.atom.io/docs/api/web-contents/#event-context-menu). The second argument is the [BrowserWindow](http://electron.atom.io/docs/api/browser-window/) the context menu was requested for.
+Should return an array of [MenuItem](http://electron.atom.io/docs/api/menu-item/)'s to be appended to the context menu. The first argument is an array of default actions that can be used. The second argument is [this `params` object](http://electron.atom.io/docs/api/web-contents/#event-context-menu). The third argument is the [BrowserWindow](http://electron.atom.io/docs/api/browser-window/) the context menu was requested for.
 
 #### showInspectElement
 

--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ menu: (actions) => [
 
 Type: `Function`
 
-Should return an array of [MenuItem](http://electron.atom.io/docs/api/menu-item/)'s to be prepended to the context menu. The first argument is an array of default actions that can be used. The first argument is [this `params` object](http://electron.atom.io/docs/api/web-contents/#event-context-menu). The second argument is the [BrowserWindow](http://electron.atom.io/docs/api/browser-window/) the context menu was requested for.
+Should return an array of [MenuItem](http://electron.atom.io/docs/api/menu-item/)'s to be prepended to the context menu. The first argument is an array of default actions that can be used. The second argument is [this `params` object](http://electron.atom.io/docs/api/web-contents/#event-context-menu). The third argument is the [BrowserWindow](http://electron.atom.io/docs/api/browser-window/) the context menu was requested for.
 
 #### append
 

--- a/readme.md
+++ b/readme.md
@@ -106,7 +106,7 @@ shouldShowMenu: (event, params) => !params.isEditable
 ## Related
 
 - [electron-debug](https://github.com/sindresorhus/electron-debug) - Adds useful debug features to your Electron app
-- [electron-config](https://github.com/sindresorhus/electron-config) - Simple config handling for your Electron app or module
+- [electron-store](https://github.com/sindresorhus/electron-store) - Save and load data like user preferences, app state, cache, etc
 - [electron-unhandled](https://github.com/sindresorhus/electron-unhandled) - Catch unhandled errors and promise rejections in your Electron app
 
 


### PR DESCRIPTION
This PR "fixes" both #14 and #43 

So basically the user can now:
- Specify a ```menu```-property in the configuration to override the default menu structure
- Give a ```transform```-function to the predefined actions in order to manipulate e.g. the data that will be copied to the clipboard
- ~~Override the ```click``` method. This will not work in combination with the transform so if you want to override the default click handler then you're basically on your own.~~

The menuItem itself will determine wheter it should be visible or not. (Although this should be easy to implement when needed)

```append``` and ```prepend``` should still work as expected. Although they now have an extra argument with the default actions.

I've changed the fixture to represent the new features.
```javascript
require('.')({
	labels: {
		cut: 'Configured Cut',
		copy: 'Configured Copy',
		paste: 'Configured Paste',
		save: 'Configured Save Image',
		copyLink: 'Configured Copy Link',
		inspect: 'Configured Inspect'
	},
	prepend: (x) => [x.CUT({transform: (content) => "modified_cut_" + content})],
	menu: (x) => [
		x.SEPARATOR(),
		x.COPY_LINK({transform: (content) => "modified_link_" + content}),
		x.SEPARATOR(),
		{
			label: 'Unicorn'
		},
		x.SEPARATOR(),
		x.COPY({transform: (content) => "modified_copy_" + content}),
		{
			label: 'Invisible',
			visible: false
		},
		x.PASTE({transform: (content) => "modified_paste_" + content})
	],
	append: (x) => [x.SAVE_IMAGE()]
});
```

TODO
- [x] Update README.md
- [x] Fix CI

---

Fixes #14 
Fixes #43