### PR TITLE
Expose `async` option for `menu.popup`

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,7 +130,7 @@ function create(win, opts) {
 			 * When this is being called from a webView, we can't use win as this
 			 * would refere to the webView which is not allowed to render a popup menu.
 			 */
-			menu.popup(electron.remote ? electron.remote.getCurrentWindow() : win);
+			menu.popup(electron.remote ? electron.remote.getCurrentWindow() : win, {async: opts.async});
 		}
 	});
 }

--- a/readme.md
+++ b/readme.md
@@ -103,6 +103,13 @@ Example:
 shouldShowMenu: (event, params) => !params.isEditable
 ```
 
+#### async
+
+Type: `boolean`<br>
+Default: `false`
+
+Exposed `async` option for [`menu.popup`](https://github.com/electron/electron/blob/master/docs/api/menu.md#menupopupbrowserwindow-options).
+
 ## Related
 
 - [electron-debug](https://github.com/sindresorhus/electron-debug) - Adds useful debug features to your Electron app


### PR DESCRIPTION
https://github.com/electron/electron/blob/master/docs/api/menu.md#menupopupbrowserwindow-options

The default behavior of `menu.popup` will block UI renders, so have an option to make the popup asynchronous will be better.