### PR TITLE
check if getWebContent before calling it

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const electron = require('electron');
 const {download} = require('electron-dl');
 const isDev = require('electron-is-dev');
 
-const webContents = win => win.webContents || win.getWebContents();
+const webContents = win => win.webContents || (win.getWebContents && win.getWebContents()) || undefined;
 
 function create(win, opts) {
 	webContents(win).on('context-menu', (e, props) => {


### PR DESCRIPTION
calling <webview>.getWebContents() before dom-ready event can generate TypeError win.getWebContents is not a function in earlier versions of electron.
Checking if the method exists before caling it and force to return undefined can solve this problem
```
TypeError: win.getWebContents is not a function
    at webContents (index.js?3dae:6)
    at __webpack_exports__.a (index.js?3dae:150)
    at VueComponent.mounted (Layout.vue?8c09:213)
    at callHook (vue.esm.js?efeb:2895)
    at Object.insert (vue.esm.js?efeb:4090)
    at invokeInsertHook (vue.esm.js?efeb:5864)
    at Vue$3.patch [as __patch__] (vue.esm.js?efeb:6083)
    at Vue$3.Vue._update (vue.esm.js?efeb:2637)
    at Vue$3.updateComponent (vue.esm.js?efeb:2765)
    at Watcher.get (vue.esm.js?efeb:3115)
```