### PR TITLE
Restore click arguments for save image context item

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ function create(win, opts) {
 			}, {
 				id: 'save',
 				label: 'Save Image',
-				click() {
+				click(item, win) {
 					download(win, props.srcURL);
 				}
 			}, {


### PR DESCRIPTION
#40 eliminated the arguments passed to the click events in both the save image and inspect element context menu items. However the PR description had only referenced issues with the click event in inspect element.

As a result of this change [some apps have lost the save image functionality when passing their browser window](https://github.com/mattermost/desktop/issues/707).

The cause of this failure is the fact that [electron-dl](https://github.com/sindresorhus/electron-dl/blob/master/index.js#L129) requires methods exposed by the `win` provided by the click event.