### PR TITLE
Fix "Copy Link" for linkText-less anchors

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function create(win, opts) {
 			return;
 		}
 
-		const editFlags = props.editFlags;
+		const {editFlags} = props;
 		const hasText = props.selectionText.trim().length > 0;
 		const can = type => editFlags[`can${type}`] && hasText;
 

--- a/index.js
+++ b/index.js
@@ -62,11 +62,10 @@ function create(win, opts) {
 				id: 'copyLink',
 				label: 'Copy Link',
 				click() {
-					if (process.platform === 'darwin') {
-						electron.clipboard.writeBookmark(props.linkText, props.linkURL);
-					} else {
-						electron.clipboard.writeText(props.linkURL);
-					}
+					electron.clipboard.write({
+						bookmark: props.linkText,
+						text: props.linkURL
+					});
 				}
 			}, {
 				type: 'separator'


### PR DESCRIPTION
In its current implementation, `Copy Link` on an element with no `linkText` like so

```html
<a href="https://example.com"><span class="my-icon-font-star"></span></a>
```

will result in a noop on macOS. I assume this is because `writeBookmark` requires `linkText` to exist. Looking at [the clipboard electron docs](https://electronjs.org/docs/api/clipboard#clipboardwritebookmarktitle-url-type-macos-windows), the implementation in this PR is recommended as a way to handle bookmark copying across OS's. I confirmed that this method still copies the bookmark title correctly in macOS.