### PR TITLE
Add `showCopyLink` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ function create(win, options) {
 			}];
 		}
 
-		if (props.linkURL && props.mediaType === 'none') {
+		if (options.showCopyLink && props.linkURL && props.mediaType === 'none') {
 			menuTpl = [{
 				type: 'separator'
 			}, {

--- a/readme.md
+++ b/readme.md
@@ -77,6 +77,13 @@ Default: `false`
 
 Show the `Copy Image Address` menu item when right-clicking on an image.
 
+#### showCopyLink
+
+Type: `boolean`<br>
+Default: `false`
+
+Show the `Copy Link` menu item when right-clicking on a link.
+
 #### showInspectElement
 
 Type: `boolean`<br>


### PR DESCRIPTION
Hey Sindre!

This might be useful to you as well. This adds a 'show copy link' toggle, so that it can optionally be turned on. I ended up needing this because 'copy link' was being activated on links that were internal to my app, exposing links that were meaningless (that linked to app.asar and such). 

This was not a big deal until I added the deep linking custom protocol support to my app, with aether://. Then, people started to notice that 'Copy Link', and they thought it was actually the aether links they were looking for. 

Mind that this pull request disables this 'copy link' by default. You might want to add a way to keep this true by default to not break existing users, I couldn't find an easy way to do that with a cursory look at the code. Converting the case so that it is 'hide copy link' and not 'show copy link' might fix the problem. 