### PR TITLE
Fix readme usage example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ const {app, BrowserWindow} = require('electron');
 const contextMenu = require('electron-context-menu');
 
 contextMenu({
-	prepend: (params, browserWindow) => [{
+	prepend: (defaultActions, params, browserWindow) => [{
 		label: 'Rainbow',
 		// Only show it when right-clicking images
 		visible: params.mediaType === 'image'


### PR DESCRIPTION
According to the release notes for 0.12.0 this additional `defaultActions` argument is a breaking change. This adds that to the usage example in the readme.