### PR TITLE
Filter out `false` menu items

### DIFF
--- a/fixture.js
+++ b/fixture.js
@@ -36,7 +36,8 @@ contextMenu({
 	],
 	append: () => {},
 	showCopyImageAddress: true,
-	showSaveImageAs: true
+	showSaveImageAs: true,
+	showInspectElement: false
 });
 
 (async () => {

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ const removeUnusedMenuItems = menuTemplate => {
 	let notDeletedPreviousElement;
 
 	return menuTemplate
-		.filter(menuItem => menuItem !== undefined && menuItem.visible !== false)
+		.filter(menuItem => menuItem !== undefined && menuItem !== false && menuItem.visible !== false)
 		.filter((menuItem, index, array) => {
 			const toDelete = menuItem.type === 'separator' && (!notDeletedPreviousElement || index === array.length - 1 || array[index + 1].type === 'separator');
 			notDeletedPreviousElement = toDelete ? notDeletedPreviousElement : menuItem;


### PR DESCRIPTION
Expressions such as `options.showInspectElement && defaultActions.inspect()` evaluate to `false` when the respective option is disabled and lead to an exception when creating the menu template. This can be prevented by filtering `false` items in the function `removeUnusedMenuItems`.

Fixes #68