### PR TITLE
Add menu item for looking up a word on macOS

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -67,6 +67,7 @@ declare namespace contextMenu {
 		readonly saveImage: (options: ActionOptions) => MenuItem;
 		readonly saveImageAs: (options: ActionOptions) => MenuItem;
 		readonly copyImageAddress: (options: ActionOptions) => MenuItem;
+		readonly lookUpWord: (options: ActionOptions) => MenuItem;
 	}
 
 	interface Options {
@@ -114,6 +115,13 @@ declare namespace contextMenu {
 		Default: [Only in development](https://github.com/sindresorhus/electron-is-dev)
 		*/
 		readonly showInspectElement?: boolean;
+
+		/**
+		Show the `Look Up [word]` menu item when right-clicking text on macOS.
+
+		@default true
+		*/
+		readonly showLookUpWord?: boolean;
 
 		/**
 		Overwrite labels for the default menu items. Useful for i18n.

--- a/index.d.ts
+++ b/index.d.ts
@@ -67,7 +67,7 @@ declare namespace contextMenu {
 		readonly saveImage: (options: ActionOptions) => MenuItem;
 		readonly saveImageAs: (options: ActionOptions) => MenuItem;
 		readonly copyImageAddress: (options: ActionOptions) => MenuItem;
-		readonly lookUpWord: (options: ActionOptions) => MenuItem;
+		readonly lookUpSelection: (options: ActionOptions) => MenuItem;
 	}
 
 	interface Options {
@@ -117,11 +117,11 @@ declare namespace contextMenu {
 		readonly showInspectElement?: boolean;
 
 		/**
-		Show the `Look Up [word]` menu item when right-clicking text on macOS.
+		Show the `Look Up [selection]` menu item when right-clicking text on macOS.
 
 		@default true
 		*/
-		readonly showLookUpWord?: boolean;
+		readonly showLookUpSelection?: boolean;
 
 		/**
 		Overwrite labels for the default menu items. Useful for i18n.

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 const electron = require('electron');
+const cliTruncate = require('cli-truncate');
 const {download} = require('electron-dl');
 const isDev = require('electron-is-dev');
 
@@ -126,10 +127,20 @@ const create = (win, options) => {
 						text: props.srcURL
 					});
 				}
+			}),
+			lookUpWord: decorateMenuItem({
+				id: 'lookUpWord',
+				label: `Look Up “${cliTruncate(props.selectionText.trim(), 25)}”`,
+				visible: hasText,
+				click() {
+					webContents(win).showDefinitionForSelection();
+				}
 			})
 		};
 
 		let menuTemplate = [
+			defaultActions.separator(),
+			process.platform === 'darwin' && (options.showLookUpWord !== false) && defaultActions.lookUpWord(),
 			defaultActions.separator(),
 			defaultActions.cut(),
 			defaultActions.copy(),

--- a/index.js
+++ b/index.js
@@ -128,19 +128,21 @@ const create = (win, options) => {
 					});
 				}
 			}),
-			lookUpWord: decorateMenuItem({
+			lookUpSelection: decorateMenuItem({
 				id: 'lookUpWord',
 				label: `Look Up “${cliTruncate(props.selectionText.trim(), 25)}”`,
-				visible: hasText,
+				visible: process.platform === 'darwin' && hasText,
 				click() {
-					webContents(win).showDefinitionForSelection();
+					if (process.platform === 'darwin') {
+						webContents(win).showDefinitionForSelection();
+					}
 				}
 			})
 		};
 
 		let menuTemplate = [
 			defaultActions.separator(),
-			process.platform === 'darwin' && (options.showLookUpWord !== false) && defaultActions.lookUpWord(),
+			options.showLookUpSelection !== false && defaultActions.lookUpSelection(),
 			defaultActions.separator(),
 			defaultActions.cut(),
 			defaultActions.copy(),

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"image"
 	],
 	"dependencies": {
+		"cli-truncate": "^1.1.0",
 		"electron-dl": "^1.2.0",
 		"electron-is-dev": "^1.0.1"
 	},

--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,13 @@ Default: [Only in development](https://github.com/sindresorhus/electron-is-dev)
 
 Force enable or disable the `Inspect Element` menu item.
 
+#### showLookUpWord
+
+Type: `boolean`<br>
+Default: `true`
+
+Show the `Look Up [word]` menu item when right-clicking text on macOS.
+
 #### labels
 
 Type: `Object`<br>

--- a/readme.md
+++ b/readme.md
@@ -93,12 +93,12 @@ Default: [Only in development](https://github.com/sindresorhus/electron-is-dev)
 
 Force enable or disable the `Inspect Element` menu item.
 
-#### showLookUpWord
+#### showLookUpSelection
 
 Type: `boolean`<br>
 Default: `true`
 
-Show the `Look Up [word]` menu item when right-clicking text on macOS.
+Show the `Look Up [selection]` menu item when right-clicking text on macOS.
 
 #### labels
 


### PR DESCRIPTION
Adds a menu item for looking up a selected word or phrase on macOS.

Enabled by default on macOS, can be disabled using `showLookUpWord: false`.

Closes #3.

Screenshots:

<img width="271" alt="Screenshot 2019-05-26 at 19 17 20" src="https://user-images.githubusercontent.com/1566516/58385812-1901c080-7fee-11e9-94ab-92dac4509006.png">

<img width="533" alt="Screenshot 2019-05-26 at 19 17 41" src="https://user-images.githubusercontent.com/1566516/58385813-1ef7a180-7fee-11e9-80e5-5148c3737794.png">

<img width="332" alt="Screenshot 2019-05-26 at 19 18 24" src="https://user-images.githubusercontent.com/1566516/58385814-228b2880-7fee-11e9-8519-69f5e116b066.png">

