### PR TITLE
Add Services submenu on macOS

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -61,6 +61,7 @@ declare namespace contextMenu {
 	interface Actions {
 		readonly separator: () => MenuItem;
 		readonly inspect: () => MenuItem;
+		readonly services: () => MenuItem;
 		readonly cut: (options: ActionOptions) => MenuItem;
 		readonly copy: (options: ActionOptions) => MenuItem;
 		readonly paste: (options: ActionOptions) => MenuItem;
@@ -115,6 +116,13 @@ declare namespace contextMenu {
 		Default: [Only in development](https://github.com/sindresorhus/electron-is-dev)
 		*/
 		readonly showInspectElement?: boolean;
+
+		/**
+		Show the system `Services` submenu on macOS.
+
+		@default false
+		*/
+		readonly showServices?: boolean;
 
 		/**
 		Show the `Look Up [selection]` menu item when right-clicking text on macOS.

--- a/index.d.ts
+++ b/index.d.ts
@@ -49,6 +49,11 @@ declare namespace contextMenu {
 		@default 'Inspect Element'
 		*/
 		readonly inspect?: string;
+
+		/**
+		@default 'Services'
+		*/
+		readonly services?: string;
 	}
 
 	interface ActionOptions {

--- a/index.js
+++ b/index.js
@@ -85,6 +85,7 @@ const create = (win, options) => {
 			}),
 			services: () => ({
 				id: 'services',
+				label: 'Services',
 				role: 'services',
 				visible: process.platform === 'darwin' && (props.isEditable || hasText)
 			}),

--- a/index.js
+++ b/index.js
@@ -83,6 +83,11 @@ const create = (win, options) => {
 					}
 				}
 			}),
+			services: () => ({
+				id: 'services',
+				role: 'services',
+				visible: process.platform === 'darwin' && (props.isEditable || hasText)
+			}),
 			separator: () => ({type: 'separator'}),
 			saveImage: decorateMenuItem({
 				id: 'save',
@@ -155,6 +160,7 @@ const create = (win, options) => {
 			defaultActions.copyLink(),
 			defaultActions.separator(),
 			options.showInspectElement && defaultActions.inspect(),
+			options.showServices && defaultActions.services(),
 			defaultActions.separator()
 		];
 

--- a/readme.md
+++ b/readme.md
@@ -161,6 +161,7 @@ The following options are ignored when `menu` is used:
 - `showCopyImageAddress`
 - `showSaveImageAs`
 - `showInspectElement`
+- `showServices`
 
 Default actions:
 
@@ -173,6 +174,7 @@ Default actions:
 - `copyImageAddress`
 - `copyLink`
 - `inspect`
+- `services`
 
 Example:
 

--- a/readme.md
+++ b/readme.md
@@ -100,9 +100,7 @@ Default: `false`
 
 Show the system `Services` submenu when right-clicking text on macOS.
 
-Due to [a bug in the Electron implementation](https://github.com/electron/electron/issues/18476), this menu is not identical to the "Services" submenu in the context menus of native apps.
-Instead, it looks the same as the "Services" menu in the main Application Menu.
-For this reason it is currently disabled by default.
+Note: Due to [a bug in the Electron implementation](https://github.com/electron/electron/issues/18476), this menu is not identical to the "Services" submenu in the context menus of native apps. Instead, it looks the same as the "Services" menu in the main App Menu. For this reason, it is currently disabled by default.
 
 #### showLookUpSelection
 

--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,17 @@ Default: [Only in development](https://github.com/sindresorhus/electron-is-dev)
 
 Force enable or disable the `Inspect Element` menu item.
 
+#### showServices
+
+Type: `boolean`<br>
+Default: `false`
+
+Show the system `Services` submenu when right-clicking text on macOS.
+
+Due to [a bug in the Electron implementation](https://github.com/electron/electron/issues/18476), this menu is not identical to the "Services" submenu in the context menus of native apps.
+Instead, it looks the same as the "Services" menu in the main Application Menu.
+For this reason it is currently disabled by default.
+
 #### showLookUpSelection
 
 Type: `boolean`<br>


### PR DESCRIPTION
Adds support for the system “Services” menu on macOS.

Enabled by default; can be disabled using `showServices: false`.

Only enabled for text; this seems to be standard across most Mac apps.

<hr />

Note that the menu is _not identical_ to that shown by native apps in the context menu – in fact it is the same as the “Services” submenu in the application menu in the main menubar.<br />
This is because of Electron's implementation of the `{ role: services }` menu API, and should probably be filed as a bug with Electron core (Chromium has support).

Screenshot:

<img width="636" alt="Screenshot 2019-05-26 at 21 16 28" src="https://user-images.githubusercontent.com/1566516/58386984-82d69600-7fff-11e9-97f4-ace84fc63427.png">

<hr />

Closes #72 