### PR TITLE
Improve `lookUpSelection` implementation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,6 +12,7 @@ declare namespace contextMenu {
 	interface Labels {
 		/**
 		The placeholder `{selection}` will be replaced by the currently selected text.
+
 		@default 'Look Up “{selection}”'
 		*/
 		readonly lookUpSelection?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,6 +11,13 @@ import {
 declare namespace contextMenu {
 	interface Labels {
 		/**
+		The default label for the `Look Up [selection]` menu item is dynamically generated depending on the selected text when the menu is shown.
+		If a value is set here, the provided static value will be used instead.
+		@default 'Look Up'
+		*/
+		readonly lookUpSelection?: string;
+
+		/**
 		@default 'Cut'
 		*/
 		readonly cut?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -60,14 +60,14 @@ declare namespace contextMenu {
 
 	interface Actions {
 		readonly separator: () => MenuItem;
-		readonly inspect: () => MenuItem;
+		readonly lookUpSelection: (options: ActionOptions) => MenuItem;
 		readonly cut: (options: ActionOptions) => MenuItem;
 		readonly copy: (options: ActionOptions) => MenuItem;
 		readonly paste: (options: ActionOptions) => MenuItem;
 		readonly saveImage: (options: ActionOptions) => MenuItem;
 		readonly saveImageAs: (options: ActionOptions) => MenuItem;
 		readonly copyImageAddress: (options: ActionOptions) => MenuItem;
-		readonly lookUpSelection: (options: ActionOptions) => MenuItem;
+		readonly inspect: () => MenuItem;
 	}
 
 	interface Options {

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,9 +11,8 @@ import {
 declare namespace contextMenu {
 	interface Labels {
 		/**
-		The default label for the `Look Up [selection]` menu item is dynamically generated depending on the selected text when the menu is shown.
-		If a value is set here, the provided static value will be used instead.
-		@default 'Look Up'
+		The placeholder `{selection}` will be replaced by the currently selected text.
+		@default 'Look Up “{selection}”'
 		*/
 		readonly lookUpSelection?: string;
 
@@ -124,7 +123,7 @@ declare namespace contextMenu {
 		readonly showInspectElement?: boolean;
 
 		/**
-		Show the `Look Up [selection]` menu item when right-clicking text on macOS.
+		Show the `Look Up {selection}` menu item when right-clicking text on macOS.
 
 		@default true
 		*/

--- a/index.js
+++ b/index.js
@@ -39,6 +39,17 @@ const create = (win, options) => {
 		const can = type => editFlags[`can${type}`] && hasText;
 
 		const defaultActions = {
+			separator: () => ({type: 'separator'}),
+			lookUpSelection: decorateMenuItem({
+				id: 'lookUpSelection',
+				label: `Look Up “${cliTruncate(props.selectionText.trim(), 25)}”`,
+				visible: process.platform === 'darwin' && hasText,
+				click() {
+					if (process.platform === 'darwin') {
+						webContents(win).showDefinitionForSelection();
+					}
+				}
+			}),
 			cut: decorateMenuItem({
 				id: 'cut',
 				label: 'Cut',
@@ -71,19 +82,6 @@ const create = (win, options) => {
 					webContents(win).insertText(clipboardContent);
 				}
 			}),
-			inspect: () => ({
-				id: 'inspect',
-				label: 'Inspect Element',
-				enabled: isDev,
-				click() {
-					win.inspectElement(props.x, props.y);
-
-					if (webContents(win).isDevToolsOpened()) {
-						webContents(win).devToolsWebContents.focus();
-					}
-				}
-			}),
-			separator: () => ({type: 'separator'}),
 			saveImage: decorateMenuItem({
 				id: 'save',
 				label: 'Save Image',
@@ -128,13 +126,15 @@ const create = (win, options) => {
 					});
 				}
 			}),
-			lookUpSelection: decorateMenuItem({
-				id: 'lookUpSelection',
-				label: `Look Up “${cliTruncate(props.selectionText.trim(), 25)}”`,
-				visible: process.platform === 'darwin' && hasText,
+			inspect: () => ({
+				id: 'inspect',
+				label: 'Inspect Element',
+				enabled: isDev,
 				click() {
-					if (process.platform === 'darwin') {
-						webContents(win).showDefinitionForSelection();
+					win.inspectElement(props.x, props.y);
+
+					if (webContents(win).isDevToolsOpened()) {
+						webContents(win).devToolsWebContents.focus();
 					}
 				}
 			})

--- a/index.js
+++ b/index.js
@@ -196,7 +196,7 @@ const create = (win, options) => {
 			}
 
 			// Replace placeholders in menu item labels
-			if (typeof menuItem.label === 'string') {
+			if (typeof menuItem.label === 'string' && typeof props.selectionText === 'string') {
 				menuItem.label = menuItem.label.replace('{selection}', cliTruncate(props.selectionText.trim(), 25));
 			}
 		}

--- a/index.js
+++ b/index.js
@@ -196,8 +196,9 @@ const create = (win, options) => {
 			}
 
 			// Replace placeholders in menu item labels
-			if (typeof menuItem.label === 'string' && typeof props.selectionText === 'string') {
-				menuItem.label = menuItem.label.replace('{selection}', cliTruncate(props.selectionText.trim(), 25));
+			if (typeof menuItem.label === 'string' && menuItem.label.indexOf('{selection}') !== -1) {
+				const selectionString = typeof props.selectionText === 'string' ? props.selectionText.trim() : '';
+				menuItem.label = menuItem.label.replace('{selection}', cliTruncate(selectionString, 25));
 			}
 		}
 

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ const create = (win, options) => {
 			separator: () => ({type: 'separator'}),
 			lookUpSelection: decorateMenuItem({
 				id: 'lookUpSelection',
-				label: `Look Up “${cliTruncate(props.selectionText.trim(), 25)}”`,
+				label: 'Look Up “{selection}”',
 				visible: process.platform === 'darwin' && hasText,
 				click() {
 					if (process.platform === 'darwin') {
@@ -182,12 +182,15 @@ const create = (win, options) => {
 		// TODO: https://github.com/electron/electron/issues/5869
 		menuTemplate = removeUnusedMenuItems(menuTemplate);
 
-		// Apply custom labels for default menu items
-		if (options.labels) {
-			for (const menuItem of menuTemplate) {
-				if (options.labels[menuItem.id]) {
-					menuItem.label = options.labels[menuItem.id];
-				}
+		for (const menuItem of menuTemplate) {
+			// Apply custom labels for default menu items
+			if (options.labels && options.labels[menuItem.id]) {
+				menuItem.label = options.labels[menuItem.id];
+			}
+
+			// Replace placeholders in menu item labels
+			if (typeof menuItem.label === 'string') {
+				menuItem.label = menuItem.label.replace('{selection}', cliTruncate(props.selectionText.trim(), 25));
 			}
 		}
 

--- a/readme.md
+++ b/readme.md
@@ -98,7 +98,7 @@ Force enable or disable the `Inspect Element` menu item.
 Type: `boolean`<br>
 Default: `true`
 
-Show the `Look Up [selection]` menu item when right-clicking text on macOS.
+Show the `Look Up {selection}` menu item when right-clicking text on macOS.
 
 #### labels
 
@@ -107,20 +107,20 @@ Default: `{}`
 
 Override labels for the default menu items. Useful for i18n.
 
+The placehlder `{selection}` may be used in any label, and will be replaced by the currently selected text.
+This is useful, for example, when localizing the `Look Up {selection}` menu item.
+
 Format:
 
 ```js
 {
 	labels: {
-		copy: 'Configured Copy',
-		saveImageAs: 'Configured Save Image As…'
+		copy: 'Copiar',
+		saveImageAs: 'Guardar imagen como…',
+		lookUpSelection: 'Consultar “{selection}”'
 	}
 }
 ```
-
-Note that the default label for the `Look Up [selection]` menu item is dynamically generated depending on the selected text when the menu is shown.
-For example, if the word `Electron` was selected, the menu item label would be `Look up “Electron”`.<br />
-If the label for `lookUpSelection` is overridden via the `labels` option, the provided static label will be used instead, which will not contain the selected text.
 
 #### shouldShowMenu
 

--- a/readme.md
+++ b/readme.md
@@ -105,7 +105,7 @@ Show the `Look Up [selection]` menu item when right-clicking text on macOS.
 Type: `Object`<br>
 Default: `{}`
 
-Overwrite labels for the default menu items. Useful for i18n.
+Override labels for the default menu items. Useful for i18n.
 
 Format:
 
@@ -117,6 +117,10 @@ Format:
 	}
 }
 ```
+
+Note that the default label for the `Look Up [selection]` menu item is dynamically generated depending on the selected text when the menu is shown.
+For example, if the word `Electron` was selected, the menu item label would be `Look up “Electron”`.<br />
+If the label for `lookUpSelection` is overridden via the `labels` option, the provided static label will be used instead, which will not contain the selected text.
 
 #### shouldShowMenu
 

--- a/readme.md
+++ b/readme.md
@@ -25,11 +25,21 @@ const {app, BrowserWindow} = require('electron');
 const contextMenu = require('electron-context-menu');
 
 contextMenu({
-	prepend: (defaultActions, params, browserWindow) => [{
-		label: 'Rainbow',
-		// Only show it when right-clicking images
-		visible: params.mediaType === 'image'
-	}]
+	prepend: (defaultActions, params, browserWindow) => [
+		{
+			label: 'Rainbow',
+			// Only show it when right-clicking images
+			visible: params.mediaType === 'image'
+		},
+		{
+			label: 'Search Google for “{selection}”',
+			// Only show it when right-clicking text
+			visible: (params.selectionText.trim().length > 0),
+			click: () => {
+				shell.openExternal(`https://www.google.com/search?q=${encodeURIComponent(params.selectionText)}`);
+			}
+		}
+	]
 });
 
 let mainWindow;
@@ -64,6 +74,8 @@ Should return an array of [MenuItem](https://electronjs.org/docs/api/menu-item/)
 
 The first argument is an array of default actions that can be used. The second argument is [this `params` object](https://electronjs.org/docs/api/web-contents/#event-context-menu). The third argument is the [BrowserWindow](https://electronjs.org/docs/api/browser-window/) the context menu was requested for.
 
+`MenuItem` labels may contain the the placeholder `{selection}` which will be replaced by the currently selected text as described in [`options.labels`](#labels).
+
 #### append
 
 Type: `Function`
@@ -71,6 +83,8 @@ Type: `Function`
 Should return an array of [MenuItem](https://electronjs.org/docs/api/menu-item/)'s to be appended to the context menu.
 
 The first argument is an array of default actions that can be used. The second argument is [this `params` object](https://electronjs.org/docs/api/web-contents/#event-context-menu). The third argument is the [BrowserWindow](https://electronjs.org/docs/api/browser-window/) the context menu was requested for.
+
+`MenuItem` labels may contain the the placeholder `{selection}` which will be replaced by the currently selected text as described in [`options.labels`](#labels).
 
 #### showLookUpSelection
 
@@ -116,8 +130,10 @@ Default: `{}`
 
 Override labels for the default menu items. Useful for i18n.
 
-The placehlder `{selection}` may be used in any label, and will be replaced by the currently selected text.
-This is useful, for example, when localizing the `Look Up {selection}` menu item.
+The placeholder `{selection}` may be used in any label, and will be replaced by the currently selected text, trimmed to a maximum of 25 characters length.
+This is useful when localizing the `Look Up “{selection}”` menu item, but can also be used in custom menu items – for example, to implement a `Search Google for “{selection}”` menu item.
+
+If there is no selection, the `{selection}` placeholder will be replaced by an empty string. Normally this placeholder is only useful for menu items which will only be shown when there is text selected. This can be checked using `visible: (params.selectionText.trim().length > 0)` when implementing a custom menu item, as shown in the usage example above.
 
 Format:
 
@@ -157,6 +173,8 @@ This option lets you manually pick what menu items to include. It's meant for ad
 The function passed to this option is expected to return [`MenuItem[]`](https://electronjs.org/docs/api/menu-item/). The first argument the function receives is an array of default actions that can be used. These actions are functions that can take an object with a transform property (except for `separator` and `inspect`). The transform function will be passed the content of the action and can modify it if needed.
 
 Even though you include an action, it will still only be shown/enabled when appropriate. For example, the `saveImage` action is only shown when right-clicking an image.
+
+`MenuItem` labels may contain the the placeholder `{selection}` which will be replaced by the currently selected text as described in [`options.labels`](#labels).
 
 The following options are ignored when `menu` is used:
 


### PR DESCRIPTION
Further to #71, and per discussion there and in https://github.com/sindresorhus/electron-context-menu/pull/73#discussion_r289259412:

- Change the order of menu actions in code to match the default menu order.
Note, as well as `lookUpSelection` I have moved `inspect`, which was also in the wrong place in the order.

- Add `lookUpSelection` to `Labels` interface in `index.d.ts`, <del>with note on usage (specifically, that if a static label is set, it will no longer be dynamic).
Also add a similar but more detailed note to `readme.md`.</del>

- [update] Implement `{selection}` placeholder for menu titles to enable full localisation of the `Look Up “{selection}”` item.

This commit will probably conflict with #73; if so, I will fix that one once this is committed.