### PR TITLE
Add `Copy Image` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -48,14 +48,14 @@ declare namespace contextMenu {
 		readonly copyLink?: string;
 
 		/**
-		@default 'Copy Image Address'
-		*/
-		readonly copyImageAddress?: string;
-
-		/**
 		@default 'Copy Image'
 		*/
 		readonly copyImage?: string;
+
+		/**
+		@default 'Copy Image Address'
+		*/
+		readonly copyImageAddress?: string;
 
 		/**
 		@default 'Inspect Element'
@@ -83,8 +83,8 @@ declare namespace contextMenu {
 		readonly paste: (options: ActionOptions) => MenuItem;
 		readonly saveImage: (options: ActionOptions) => MenuItem;
 		readonly saveImageAs: (options: ActionOptions) => MenuItem;
-		readonly copyImageAddress: (options: ActionOptions) => MenuItem;
 		readonly copyImage: (options: ActionOptions) => MenuItem;
+		readonly copyImageAddress: (options: ActionOptions) => MenuItem;
 		readonly inspect: () => MenuItem;
 		readonly services: () => MenuItem;
 	}
@@ -126,18 +126,18 @@ declare namespace contextMenu {
 		readonly showLookUpSelection?: boolean;
 
 		/**
-		Show the `Copy Image Address` menu item when right-clicking on an image.
-
-		@default false
-		*/
-		readonly showCopyImageAddress?: boolean;
-
-		/**
 		Show the `Copy Image` menu item when right-clicking on an image.
 
 		@default true
 		*/
 		readonly showCopyImage?: boolean;
+
+		/**
+		Show the `Copy Image Address` menu item when right-clicking on an image.
+
+		@default false
+		*/
+		readonly showCopyImageAddress?: boolean;
 
 		/**
 		Show the `Save Image As…` menu item when right-clicking on an image.
@@ -207,11 +207,12 @@ declare namespace contextMenu {
 
 		The following options are ignored when `menu` is used:
 
+		- `showCopyImage`
 		- `showCopyImageAddress`
 		- `showSaveImageAs`
 		- `showInspectElement`
 
-		@default [defaultActions.cut(), defaultActions.copy(), defaultActions.paste(), defaultActions.separator(), defaultActions.saveImage(), defaultActions.saveImageAs(), defaultActions.copyImageAddress(), defaultActions.separator(), defaultActions.copyLink(), defaultActions.separator(), defaultActions.inspect()]
+		@default [defaultActions.cut(), defaultActions.copy(), defaultActions.paste(), defaultActions.separator(), defaultActions.saveImage(), defaultActions.saveImageAs(), defaultActions.copyImage(), defaultActions.copyImageAddress(), defaultActions.separator(), defaultActions.copyLink(), defaultActions.separator(), defaultActions.inspect()]
 		*/
 		readonly menu?: (
 			defaultActions: Actions,

--- a/index.d.ts
+++ b/index.d.ts
@@ -53,6 +53,11 @@ declare namespace contextMenu {
 		readonly copyImageAddress?: string;
 
 		/**
+		@default 'Copy Image'
+		*/
+		readonly copyImage?: string;
+
+		/**
 		@default 'Inspect Element'
 		*/
 		readonly inspect?: string;
@@ -79,6 +84,7 @@ declare namespace contextMenu {
 		readonly saveImage: (options: ActionOptions) => MenuItem;
 		readonly saveImageAs: (options: ActionOptions) => MenuItem;
 		readonly copyImageAddress: (options: ActionOptions) => MenuItem;
+		readonly copyImage: (options: ActionOptions) => MenuItem;
 		readonly inspect: () => MenuItem;
 		readonly services: () => MenuItem;
 	}
@@ -125,6 +131,13 @@ declare namespace contextMenu {
 		@default false
 		*/
 		readonly showCopyImageAddress?: boolean;
+
+		/**
+		Show the `Copy Image` menu item when right-clicking on an image.
+
+		@default true
+		*/
+		readonly showCopyImage?: boolean;
 
 		/**
 		Show the `Save Image As…` menu item when right-clicking on an image.

--- a/index.js
+++ b/index.js
@@ -83,14 +83,6 @@ const create = (win, options) => {
 					webContents(win).insertText(clipboardContent);
 				}
 			}),
-			copyImage: decorateMenuItem({
-				id: 'copyImage',
-				label: 'Copy Image',
-				visible: props.mediaType === 'image',
-				click() {
-					webContents(win).copyImageAt(props.x, props.y);
-				}
-			}),
 			saveImage: decorateMenuItem({
 				id: 'save',
 				label: 'Save Image',
@@ -120,6 +112,14 @@ const create = (win, options) => {
 						bookmark: props.linkText,
 						text: props.linkURL
 					});
+				}
+			}),
+			copyImage: decorateMenuItem({
+				id: 'copyImage',
+				label: 'Copy Image',
+				visible: props.mediaType === 'image',
+				click() {
+					webContents(win).copyImageAt(props.x, props.y);
 				}
 			}),
 			copyImageAddress: decorateMenuItem({

--- a/index.js
+++ b/index.js
@@ -83,6 +83,14 @@ const create = (win, options) => {
 					webContents(win).insertText(clipboardContent);
 				}
 			}),
+			copyImage: decorateMenuItem({
+				id: 'copyImage',
+				label: 'Copy Image',
+				visible: props.mediaType === 'image',
+				click() {
+					webContents(win).copyImageAt(props.x, props.y);
+				}
+			}),
 			saveImage: decorateMenuItem({
 				id: 'save',
 				label: 'Save Image',
@@ -157,6 +165,7 @@ const create = (win, options) => {
 			defaultActions.separator(),
 			defaultActions.saveImage(),
 			options.showSaveImageAs && defaultActions.saveImageAs(),
+			defaultActions.copyImage(),
 			options.showCopyImageAddress && defaultActions.copyImageAddress(),
 			defaultActions.separator(),
 			defaultActions.copyLink(),

--- a/index.js
+++ b/index.js
@@ -165,7 +165,7 @@ const create = (win, options) => {
 			defaultActions.separator(),
 			defaultActions.saveImage(),
 			options.showSaveImageAs && defaultActions.saveImageAs(),
-			defaultActions.copyImage(),
+			options.showCopyImage !== false && defaultActions.copyImage(),
 			options.showCopyImageAddress && defaultActions.copyImageAddress(),
 			defaultActions.separator(),
 			defaultActions.copyLink(),

--- a/readme.md
+++ b/readme.md
@@ -93,19 +93,19 @@ Default: `true`
 
 Show the `Look Up {selection}` menu item when right-clicking text on macOS.
 
-#### showCopyImageAddress
-
-Type: `boolean`<br>
-Default: `false`
-
-Show the `Copy Image Address` menu item when right-clicking on an image.
-
 #### showCopyImage
 
 Type: `boolean`<br>
 Default: `true`
 
 Show the `Copy Image` menu item when right-clicking on an image.
+
+#### showCopyImageAddress
+
+Type: `boolean`<br>
+Default: `false`
+
+Show the `Copy Image Address` menu item when right-clicking on an image.
 
 #### showSaveImageAs
 
@@ -183,6 +183,7 @@ Even though you include an action, it will still only be shown/enabled when appr
 The following options are ignored when `menu` is used:
 
 - `showLookUpSelection`
+- `showCopyImage`
 - `showCopyImageAddress`
 - `showSaveImageAs`
 - `showInspectElement`
@@ -195,9 +196,9 @@ Default actions:
 - `cut`
 - `copy`
 - `paste`
-- `copyImage`
 - `saveImage`
 - `saveImageAs`
+- `copyImage`
 - `copyImageAddress`
 - `copyLink`
 - `inspect`

--- a/readme.md
+++ b/readme.md
@@ -100,6 +100,13 @@ Default: `false`
 
 Show the `Copy Image Address` menu item when right-clicking on an image.
 
+#### showCopyImage
+
+Type: `boolean`<br>
+Default: `true`
+
+Show the `Copy Image` menu item when right-clicking on an image.
+
 #### showSaveImageAs
 
 Type: `boolean`<br>
@@ -188,6 +195,7 @@ Default actions:
 - `cut`
 - `copy`
 - `paste`
+- `copyImage`
 - `saveImage`
 - `saveImageAs`
 - `copyImageAddress`


### PR DESCRIPTION
@sindresorhus 

This PR follows up on https://github.com/sindresorhus/caprine/pull/943.

A couple of mentions:

- Electron can only copy `png` or `jpg` images. I tried with `webp`, for example, but `electron.nativeImage` has no support for it. I suppose we could convert to `png` or `jpg`.. thoughts?
- I'm not sure if it should support `file://` protocol or not
- Used the `request` module for fetching the image buffer

Thanks!