### PR TITLE
Add `WebContents` to `browserWindow` TypeScript type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,8 @@ import {
 	WebviewTag,
 	ContextMenuParams,
 	MenuItemConstructorOptions,
-	Event as ElectronEvent
+	Event as ElectronEvent,
+	WebContents
 } from 'electron';
 
 declare namespace contextMenu {
@@ -95,7 +96,7 @@ declare namespace contextMenu {
 		Window or WebView to add the context menu to.
 		When not specified, the context menu will be added to all existing and new windows.
 		*/
-		readonly window?: BrowserWindow | WebviewTag;
+		readonly window?: BrowserWindow | WebviewTag | WebContents;
 
 		/**
 		Should return an array of [menu items](https://electronjs.org/docs/api/menu-item) to be prepended to the context menu.
@@ -105,7 +106,7 @@ declare namespace contextMenu {
 		readonly prepend?: (
 			defaultActions: Actions,
 			params: ContextMenuParams,
-			browserWindow: BrowserWindow | WebviewTag
+			browserWindow: BrowserWindow | WebviewTag | WebContents
 		) => MenuItemConstructorOptions[];
 
 		/**
@@ -116,7 +117,7 @@ declare namespace contextMenu {
 		readonly append?: (
 			defaultActions: Actions,
 			param: ContextMenuParams,
-			browserWindow: BrowserWindow | WebviewTag
+			browserWindow: BrowserWindow | WebviewTag | WebContents
 		) => MenuItemConstructorOptions[];
 
 		/**
@@ -220,7 +221,7 @@ declare namespace contextMenu {
 		readonly menu?: (
 			defaultActions: Actions,
 			params: ContextMenuParams,
-			browserWindow: BrowserWindow | WebviewTag
+			browserWindow: BrowserWindow | WebviewTag | WebContents
 		) => MenuItemConstructorOptions[];
 	}
 }

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,4 +1,5 @@
 import {expectType} from 'tsd';
+import {app, BrowserWindow, shell} from 'electron';
 import contextMenu = require('.');
 
 expectType<void>(contextMenu());
@@ -11,3 +12,13 @@ contextMenu({
 		}
 	]
 });
+
+app.on('web-contents-created', (event, webContents) => {
+	contextMenu({
+		prepend: (defaultActions, params) => [{
+			label: 'Rainbow',
+			visible: params.mediaType === 'image'
+		}],
+		window: webContents
+	});
+})

--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,7 @@ Type: `object`
 
 #### window
 
-Type: `BrowserWindow | WebView`
+Type: `BrowserWindow | WebViewTag | WebContents`
 
 Window or WebView to add the context menu to.
 


### PR DESCRIPTION
As described in https://github.com/sindresorhus/electron-context-menu/issues/65#issuecomment-486619283, it is possible to use `webContents` as `window` value. Tried locally and it works as expected.