### PR TITLE
Fixed broken option 'showSaveImage'

### DIFF
--- a/index.js
+++ b/index.js
@@ -181,7 +181,7 @@ const create = (win, options) => {
 			defaultActions.copy(),
 			defaultActions.paste(),
 			defaultActions.separator(),
-			defaultActions.saveImage(),
+			options.showSaveImage && defaultActions.saveImage(),
 			options.showSaveImageAs && defaultActions.saveImageAs(),
 			options.showCopyImage !== false && defaultActions.copyImage(),
 			options.showCopyImageAddress && defaultActions.copyImageAddress(),


### PR DESCRIPTION
When creating a context menu I found that `options.showSaveImage` did not affect the creation of the respective menu item--no matter if you set it to `true` or `false` it still shows up. This fixes that.

Really love the library, by the way, thank you for your time with this :)