### PR TITLE
Add `showSaveImage` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -144,7 +144,7 @@ declare namespace contextMenu {
 		readonly showCopyImageAddress?: boolean;
 
 		/**
-		Show the `Save Image As…` menu item when right-clicking on an image.
+		Show the `Save Image` menu item when right-clicking on an image.
 
 		@default false
 		 */

--- a/index.d.ts
+++ b/index.d.ts
@@ -147,6 +147,13 @@ declare namespace contextMenu {
 		Show the `Save Image As…` menu item when right-clicking on an image.
 
 		@default false
+		 */
+		readonly showSaveImage?: boolean;
+
+		/**
+		Show the `Save Image As…` menu item when right-clicking on an image.
+
+		@default false
 		*/
 		readonly showSaveImageAs?: boolean;
 

--- a/index.js
+++ b/index.js
@@ -181,7 +181,7 @@ const create = (win, options) => {
 			defaultActions.copy(),
 			defaultActions.paste(),
 			defaultActions.separator(),
-			defaultActions.saveImage(),
+			options.showSaveImage && defaultActions.saveImage(),
 			options.showSaveImageAs && defaultActions.saveImageAs(),
 			options.showCopyImage !== false && defaultActions.copyImage(),
 			options.showCopyImageAddress && defaultActions.copyImageAddress(),

--- a/readme.md
+++ b/readme.md
@@ -104,6 +104,13 @@ Default: `false`
 
 Show the `Copy Image Address` menu item when right-clicking on an image.
 
+#### showSaveImage
+
+Type: `boolean`\
+Default: `false`
+
+Show the `Save Image` menu item when right-clicking on an image.
+
 #### showSaveImageAs
 
 Type: `boolean`\


### PR DESCRIPTION
after some playing around with the context menu,
i found that is not possible to hide the defaultAction "saveImage".

we can edit the label with `saveImage: "SaveImage?!!"`
but we cant hide it, so i looked in the source and it was simply not implemented?
now it is...

