### PR TITLE
Fix Electron 9 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const cliTruncate = require('cli-truncate');
 const {download} = require('electron-dl');
 const isDev = require('electron-is-dev');
 
-const webContents = win => win.webContents || electron.remote.webContents.fromId(win.getWebContentsId());
+const webContents = win => win.webContents || (win.getWebContentsId && electron.remote.webContents.fromId(win.getWebContentsId()));
 
 const decorateMenuItem = menuItem => {
 	return (options = {}) => {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const cliTruncate = require('cli-truncate');
 const {download} = require('electron-dl');
 const isDev = require('electron-is-dev');
 
-const webContents = win => win.webContents || (win.getWebContents && win.getWebContents());
+const webContents = win => win.webContents || electron.remote.webContents.fromId(win.getWebContentsId());
 
 const decorateMenuItem = menuItem => {
 	return (options = {}) => {


### PR DESCRIPTION
The webview.getWebContents method was removed in Electron 9.x.x so it no longer works when using WebView. 

https://www.electronjs.org/docs/breaking-changes#planned-breaking-api-changes-90

So I used remote and it worked. I also confirmed that it works even if WebView is not used.

EnableRemoteModule must be true in WebPreference.
