### PR TITLE
Fix the deprecated <webview>.getWebContents() introduced in Electron 9.0.0 

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const cliTruncate = require('cli-truncate');
 const {download} = require('electron-dl');
 const isDev = require('electron-is-dev');
 
-const webContents = win => win.webContents || (win.getWebContents && win.getWebContents());
+const webContents = win => win.webContents || (win.getWebContentsId && electron.remote.webContents.fromId(win.getWebContentsId()));
 
 const decorateMenuItem = menuItem => {
 	return (options = {}) => {


### PR DESCRIPTION
Simple fix
From `win.getWebContents()`

To `electron.remote.webContents.fromId(win.getWebContentsId())`