### PR TITLE
Fix error when window is already destroyed

### DIFF
--- a/index.js
+++ b/index.js
@@ -310,6 +310,10 @@ const create = (win, options) => {
 	webContents(win).on('context-menu', handleContextMenu);
 
 	return () => {
+		if (win.isDestroyed()) {
+			return;
+		}
+
 		webContents(win).removeListener('context-menu', handleContextMenu);
 	};
 };

--- a/index.js
+++ b/index.js
@@ -338,7 +338,10 @@ module.exports = (options = {}) => {
 		};
 
 		win.once('closed', removeDisposable);
-		disposables.push(() => win.off('closed', removeDisposable));
+
+		disposables.push(() => {
+			win.off('closed', removeDisposable);
+		});
 	};
 
 	const dispose = () => {

--- a/index.js
+++ b/index.js
@@ -328,9 +328,17 @@ module.exports = (options = {}) => {
 		}
 
 		const disposeMenu = create(win, options);
-		disposables.push(() => {
-			disposeMenu();
-		});
+
+		disposables.push(disposeMenu);
+		const removeDisposable = () => {
+			const index = disposables.indexOf(disposeMenu);
+			if (index !== -1) {
+				disposables.splice(index, 1);
+			}
+		};
+
+		win.once('closed', removeDisposable);
+		disposables.push(() => win.off('closed', removeDisposable));
 	};
 
 	const dispose = () => {


### PR DESCRIPTION
The dispose function doesn't handle the window being destroyed.

For example when creating multiple windows and closing one calling `dispose` will throw
```
Uncaught Error: Object has been destroyed
```

An alternative _(or addition)_ to this fix would be to remove the _disposable_ when the window is `closed`.
https://github.com/sindresorhus/electron-context-menu/blob/a88871809b8b99ea03f88abb6424da86e64db485/index.js#L326-L329