### PR TITLE
Add support for `BrowserView`

### DIFF
--- a/index.js
+++ b/index.js
@@ -337,7 +337,8 @@ module.exports = (options = {}) => {
 			}
 		};
 
-		win.once('closed', removeDisposable);
+		if (typeof win.once !== 'undefined')  // support for BrowserView
+			win.once('closed', removeDisposable);
 
 		disposables.push(() => {
 			win.off('closed', removeDisposable);

--- a/index.js
+++ b/index.js
@@ -337,8 +337,9 @@ module.exports = (options = {}) => {
 			}
 		};
 
-		if (typeof win.once !== 'undefined')  // support for BrowserView
+		if (typeof win.once !== 'undefined') { // Support for BrowserView
 			win.once('closed', removeDisposable);
+		}
 
 		disposables.push(() => {
 			win.off('closed', removeDisposable);


### PR DESCRIPTION
Now it's possible to create a context menu for BrowserView:

    browserview.webContents.on('did-finish-load', () => {
        contextMenu({window: browserview, ...
    });

Fixes #125