### PR TITLE
fix save image crash from browserview/upgrade electron-dl to v3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 	],
 	"dependencies": {
 		"cli-truncate": "^2.0.0",
-		"electron-dl": "^3.0.0",
+		"electron-dl": "^3.1.0",
 		"electron-is-dev": "^1.0.1"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Upgrade electron-dl dependency to prevent crash when using "save image" or derivatives from a browserview context