### PR TITLE
Fix Electron 11 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -364,7 +364,8 @@ module.exports = (options = {}) => {
 				init(win);
 			};
 
-			win.addEventListener('dom-ready', onDomReady, {once: true});
+			const listenerFunction = win.addEventListener || win.addListener;
+			listenerFunction('dom-ready', onDomReady, {once: true});
 
 			disposables.push(() => {
 				win.removeEventListener('dom-ready', onDomReady, {once: true});


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/electron-context-menu/issues/123

This PR checks for the existence of `win.addEventListener` first before calling the function. If it doesn't, use `win.addListener`.