### PR TITLE
Fix Electron 12 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 if (process.type === 'renderer') {
-	throw new Error('Cannot use electron-context-menu in renderer process!');
+	throw new Error('Cannot use electron-context-menu in the renderer process!');
 }
 
 const electron = require('electron');

--- a/index.js
+++ b/index.js
@@ -1,9 +1,4 @@
 'use strict';
-
-if (process.type === 'renderer') {
-	throw new Error('Cannot use electron-context-menu in the renderer process!');
-}
-
 const electron = require('electron');
 const cliTruncate = require('cli-truncate');
 const {download} = require('electron-dl');
@@ -314,6 +309,10 @@ const create = (win, options) => {
 };
 
 module.exports = (options = {}) => {
+	if (process.type === 'renderer') {
+		throw new Error('Cannot use electron-context-menu in renderer process!');
+	}
+
 	let isDisposed = false;
 	const disposables = [];
 

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 
 Electron doesn't have a built-in context menu. You're supposed to handle that yourself. But it's both tedious and hard to get right. This module gives you a nice extensible context menu with spellchecking and items like `Cut`/`Copy`/`Paste` for text, `Save Image` for images, and `Copy Link` for links. It also adds an `Inspect Element` menu item when in development to quickly view items in the inspector like in Chrome.
 
-You can use this module directly in both the main and renderer process.
+You can use this module only in the main process.
 
 ## Install
 

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 
 Electron doesn't have a built-in context menu. You're supposed to handle that yourself. But it's both tedious and hard to get right. This module gives you a nice extensible context menu with spellchecking and items like `Cut`/`Copy`/`Paste` for text, `Save Image` for images, and `Copy Link` for links. It also adds an `Inspect Element` menu item when in development to quickly view items in the inspector like in Chrome.
 
-You can use this module only in the main process.
+This package can only be used in the main process.
 
 ## Install
 


### PR DESCRIPTION
Removing remote to be compatible with Electron 12 and removing renderer support so we don't need to implement workarounds for remote module.

Closes: #133 