### PR TITLE
Expose `event` parameter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -123,7 +123,8 @@ declare namespace contextMenu {
 		readonly prepend?: (
 			defaultActions: Actions,
 			parameters: ContextMenuParams,
-			browserWindow: BrowserWindow | BrowserView | WebviewTag | WebContents
+			browserWindow: BrowserWindow | BrowserView | WebviewTag | WebContents,
+			event: Event
 		) => MenuItemConstructorOptions[];
 
 		/**
@@ -134,7 +135,8 @@ declare namespace contextMenu {
 		readonly append?: (
 			defaultActions: Actions,
 			parameters: ContextMenuParams,
-			browserWindow: BrowserWindow | BrowserView | WebviewTag | WebContents
+			browserWindow: BrowserWindow | BrowserView | WebviewTag | WebContents,
+			event: Event
 		) => MenuItemConstructorOptions[];
 
 		/**
@@ -233,7 +235,8 @@ declare namespace contextMenu {
 		*/
 		readonly shouldShowMenu?: (
 			event: ElectronEvent,
-			parameters: ContextMenuParams
+			parameters: ContextMenuParams,
+			event: Event
 		) => boolean;
 
 		/**
@@ -269,7 +272,8 @@ declare namespace contextMenu {
 			defaultActions: Actions,
 			parameters: ContextMenuParams,
 			browserWindow: BrowserWindow | BrowserView | WebviewTag | WebContents,
-			dictionarySuggestions: MenuItemConstructorOptions[]
+			dictionarySuggestions: MenuItemConstructorOptions[],
+			event: Event
 		) => MenuItemConstructorOptions[];
 	}
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -124,7 +124,7 @@ declare namespace contextMenu {
 			defaultActions: Actions,
 			parameters: ContextMenuParams,
 			browserWindow: BrowserWindow | BrowserView | WebviewTag | WebContents,
-			event: Event
+			event: ElectronEvent
 		) => MenuItemConstructorOptions[];
 
 		/**
@@ -136,7 +136,7 @@ declare namespace contextMenu {
 			defaultActions: Actions,
 			parameters: ContextMenuParams,
 			browserWindow: BrowserWindow | BrowserView | WebviewTag | WebContents,
-			event: Event
+			event: ElectronEvent
 		) => MenuItemConstructorOptions[];
 
 		/**
@@ -235,8 +235,7 @@ declare namespace contextMenu {
 		*/
 		readonly shouldShowMenu?: (
 			event: ElectronEvent,
-			parameters: ContextMenuParams,
-			event: Event
+			parameters: ContextMenuParams
 		) => boolean;
 
 		/**
@@ -247,7 +246,8 @@ declare namespace contextMenu {
 		The first argument the function receives is an array of default actions that can be used. These actions are functions that can take an object with a transform property (except for `separator` and `inspect`). The transform function will be passed the content of the action and can modify it if needed. If you use `transform` on `cut`, `copy`, or `paste`, they will convert rich text to plain text.
 		The second argument is [this `parameters` object](https://electronjs.org/docs/api/web-contents/#event-context-menu).
 		The third argument is the [BrowserWindow](https://electronjs.org/docs/api/browser-window/) the context menu was requested for.
-		The last argument is an Array of menu items for dictionary suggestions. This should be used if you wish to implement spellcheck in your custom menu.
+		The fourth argument is an Array of menu items for dictionary suggestions. This should be used if you wish to implement spellcheck in your custom menu.
+		The last argument is the event object passed to the `context-menu` event in web contents.
 
 		Even though you include an action, it will still only be shown/enabled when appropriate. For example, the `saveImage` action is only shown when right-clicking an image.
 
@@ -273,7 +273,7 @@ declare namespace contextMenu {
 			parameters: ContextMenuParams,
 			browserWindow: BrowserWindow | BrowserView | WebviewTag | WebContents,
 			dictionarySuggestions: MenuItemConstructorOptions[],
-			event: Event
+			event: ElectronEvent
 		) => MenuItemConstructorOptions[];
 	}
 }

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ const removeUnusedMenuItems = menuTemplate => {
 
 const create = (win, options) => {
 	const handleContextMenu = (event, props) => {
-		if (typeof options.shouldShowMenu === 'function' && options.shouldShowMenu(event, props, event) === false) {
+		if (typeof options.shouldShowMenu === 'function' && options.shouldShowMenu(event, props) === false) {
 			return;
 		}
 

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ const removeUnusedMenuItems = menuTemplate => {
 
 const create = (win, options) => {
 	const handleContextMenu = (event, props) => {
-		if (typeof options.shouldShowMenu === 'function' && options.shouldShowMenu(event, props) === false) {
+		if (typeof options.shouldShowMenu === 'function' && options.shouldShowMenu(event, props, event) === false) {
 			return;
 		}
 
@@ -255,11 +255,11 @@ const create = (win, options) => {
 		];
 
 		if (options.menu) {
-			menuTemplate = options.menu(defaultActions, props, win, dictionarySuggestions);
+			menuTemplate = options.menu(defaultActions, props, win, dictionarySuggestions, event);
 		}
 
 		if (options.prepend) {
-			const result = options.prepend(defaultActions, props, win);
+			const result = options.prepend(defaultActions, props, win, event);
 
 			if (Array.isArray(result)) {
 				menuTemplate.unshift(...result);
@@ -267,7 +267,7 @@ const create = (win, options) => {
 		}
 
 		if (options.append) {
-			const result = options.append(defaultActions, props, win);
+			const result = options.append(defaultActions, props, win, event);
 
 			if (Array.isArray(result)) {
 				menuTemplate.push(...result);

--- a/readme.md
+++ b/readme.md
@@ -84,7 +84,7 @@ Type: `Function`
 
 Should return an array of [MenuItem](https://electronjs.org/docs/api/menu-item/)'s to be prepended to the context menu.
 
-The first argument is an array of default actions that can be used. The second argument is [this `parameters` object](https://electronjs.org/docs/api/web-contents/#event-context-menu). The third argument is the [BrowserWindow](https://electronjs.org/docs/api/browser-window/) the context menu was requested for.
+The first argument is an array of default actions that can be used. The second argument is [this `parameters` object](https://electronjs.org/docs/api/web-contents/#event-context-menu). The third argument is the [BrowserWindow](https://electronjs.org/docs/api/browser-window/) the context menu was requested for. The fourth argument is the context menu event.
 
 `MenuItem` labels may contain the placeholder `{selection}` which will be replaced by the currently selected text as described in [`options.labels`](#labels).
 
@@ -94,7 +94,7 @@ Type: `Function`
 
 Should return an array of [MenuItem](https://electronjs.org/docs/api/menu-item/)'s to be appended to the context menu.
 
-The first argument is an array of default actions that can be used. The second argument is [this `parameters` object](https://electronjs.org/docs/api/web-contents/#event-context-menu). The third argument is the [BrowserWindow](https://electronjs.org/docs/api/browser-window/) the context menu was requested for.
+The first argument is an array of default actions that can be used. The second argument is [this `parameters` object](https://electronjs.org/docs/api/web-contents/#event-context-menu). The third argument is the [BrowserWindow](https://electronjs.org/docs/api/browser-window/) the context menu was requested for. The fourth argument is the context menu event.
 
 `MenuItem` labels may contain the placeholder `{selection}` which will be replaced by the currently selected text as described in [`options.labels`](#labels).
 
@@ -207,7 +207,7 @@ Type: `Function`
 
 This option lets you manually pick what menu items to include. It's meant for advanced needs. The default menu with the other options should be enough for most use-cases, and it ensures correct behavior, for example, correct order of menu items. So prefer the `append` and `prepend` option instead of `menu` whenever possible.
 
-The function passed to this option is expected to return [`MenuItem[]`](https://electronjs.org/docs/api/menu-item/). The first argument the function receives is an array of default actions that can be used. These actions are functions that can take an object with a transform property (except for `separator` and `inspect`). The transform function will be passed the content of the action and can modify it if needed. If you use `transform` on `cut`, `copy`, or `paste`, they will convert rich text to plain text. The second argument is [this `parameters` object](https://electronjs.org/docs/api/web-contents/#event-context-menu). The third argument is the [BrowserWindow](https://electronjs.org/docs/api/browser-window/) the context menu was requested for. The last argument is an Array of menu items for dictionary suggestions. This should be used if you wish to implement spellcheck in your custom menu.
+The function passed to this option is expected to return [`MenuItem[]`](https://electronjs.org/docs/api/menu-item/). The first argument the function receives is an array of default actions that can be used. These actions are functions that can take an object with a transform property (except for `separator` and `inspect`). The transform function will be passed the content of the action and can modify it if needed. If you use `transform` on `cut`, `copy`, or `paste`, they will convert rich text to plain text. The second argument is [this `parameters` object](https://electronjs.org/docs/api/web-contents/#event-context-menu). The third argument is the [BrowserWindow](https://electronjs.org/docs/api/browser-window/) the context menu was requested for. The fourth argument is an Array of menu items for dictionary suggestions. This should be used if you wish to implement spellcheck in your custom menu. The last argument is the context menu event.
 
 Even though you include an action, it will still only be shown/enabled when appropriate. For example, the `saveImage` action is only shown when right-clicking an image.
 


### PR DESCRIPTION
This PR adds the optional parameter `event` to all methods provided in `options`. This allows you to access the event target.