### PR TITLE
Add menu option to open image externally

### DIFF
--- a/fixtures/fixture-toggle.html
+++ b/fixtures/fixture-toggle.html
@@ -41,6 +41,7 @@
 					append: () => {},
 					showCopyImageAddress: true,
 					showSaveImageAs: true,
+					showOpenImageExternally: true,
 					showInspectElement: false
 				});
 			}

--- a/fixtures/fixture.js
+++ b/fixtures/fixture.js
@@ -38,6 +38,7 @@ contextMenu({
 	append: () => {},
 	showCopyImageAddress: true,
 	showSaveImageAs: true,
+	showOpenImageExternally: true,
 	showInspectElement: false,
 	showSaveLinkAs: true
 });

--- a/index.d.ts
+++ b/index.d.ts
@@ -72,6 +72,11 @@ declare namespace contextMenu {
 		readonly copyImageAddress?: string;
 
 		/**
+		@default 'Open Image in Browser'
+		*/
+		readonly openImageExternally?: string;
+
+		/**
 		@default 'Inspect Element'
 		*/
 		readonly inspect?: string;
@@ -104,6 +109,7 @@ declare namespace contextMenu {
 		readonly copyLink: (options: ActionOptions) => MenuItemConstructorOptions;
 		readonly copyImage: (options: ActionOptions) => MenuItemConstructorOptions;
 		readonly copyImageAddress: (options: ActionOptions) => MenuItemConstructorOptions;
+		readonly openImageExternally: (options: ActionOptions) => MenuItemConstructorOptions;
 		readonly inspect: () => MenuItemConstructorOptions;
 		readonly services: () => MenuItemConstructorOptions;
 	}
@@ -166,6 +172,13 @@ declare namespace contextMenu {
 		@default false
 		*/
 		readonly showCopyImageAddress?: boolean;
+
+		/**
+		Show the `Open Image in Browser` menu item when right-clicking on an image.
+
+		@default false
+		*/
+		readonly showOpenImageExternally?: boolean;
 
 		/**
 		Show the `Save Image` menu item when right-clicking on an image.
@@ -259,6 +272,7 @@ declare namespace contextMenu {
 		- `showSearchWithGoogle`
 		- `showCopyImage`
 		- `showCopyImageAddress`
+		- `showOpenImageExternally`
 		- `showSaveImageAs`
 		- `showSaveLinkAs`
 		- `showInspectElement`
@@ -266,7 +280,7 @@ declare namespace contextMenu {
 
 		To get spellchecking, “Correct Automatically”, and “Learn Spelling” in the menu, please enable the `spellcheck` preference in browser window: `new BrowserWindow({webPreferences: {spellcheck: true}})`
 
-		@default [...dictionarySuggestions, defaultActions.separator(), defaultActions.separator(), defaultActions.learnSpelling(), defaultActions.separator(), defaultActions.lookUpSelection(), defaultActions.separator(),defaultActions.searchWithGoogle(), defaultActions.cut(), defaultActions.copy(), defaultActions.paste(), defaultActions.separator(), defaultActions.saveImage(), defaultActions.saveImageAs(), defaultActions.copyLink(), defaultActions.copyImage(), defaultActions.copyImageAddress(), defaultActions.separator(), defaultActions.copyLink(), defaultActions.saveLinkAs(), defaultActions.separator(), defaultActions.inspect()]
+		@default [...dictionarySuggestions, defaultActions.separator(), defaultActions.separator(), defaultActions.learnSpelling(), defaultActions.separator(), defaultActions.lookUpSelection(), defaultActions.separator(),defaultActions.searchWithGoogle(), defaultActions.cut(), defaultActions.copy(), defaultActions.paste(), defaultActions.separator(), defaultActions.saveImage(), defaultActions.saveImageAs(), defaultActions.copyLink(), defaultActions.copyImage(), defaultActions.copyImageAddress(), defaultActions.openImageExternally(), defaultActions.separator(), defaultActions.copyLink(), defaultActions.saveLinkAs(), defaultActions.separator(), defaultActions.inspect()]
 		*/
 		readonly menu?: (
 			defaultActions: Actions,

--- a/index.js
+++ b/index.js
@@ -180,6 +180,16 @@ const create = (win, options) => {
 					});
 				}
 			}),
+			openImageExternally: decorateMenuItem({
+				id: 'openImageExternally',
+				label: 'Open &Image Externally',
+				visible: props.mediaType === 'image',
+				click(menuItem) {
+					props.srcURL = menuItem.transform ? menuItem.transform(props.srcURL) : props.srcURL;
+
+					electron.shell.openExternal(props.srcURL);
+				}
+			}),
 			inspect: () => ({
 				id: 'inspect',
 				label: 'I&nspect Element',
@@ -245,6 +255,7 @@ const create = (win, options) => {
 			options.showSaveImageAs && defaultActions.saveImageAs(),
 			options.showCopyImage !== false && defaultActions.copyImage(),
 			options.showCopyImageAddress && defaultActions.copyImageAddress(),
+			options.showOpenImageExternally && defaultActions.openImageExternally(),
 			defaultActions.separator(),
 			defaultActions.copyLink(),
 			options.showSaveLinkAs && defaultActions.saveLinkAs(),

--- a/readme.md
+++ b/readme.md
@@ -126,6 +126,13 @@ Default: `false`
 
 Show the `Copy Image Address` menu item when right-clicking on an image.
 
+#### showOpenImageExternally
+
+Type: `boolean`\
+Default: `false`
+
+Show the `Open Image in Browser` menu item when right-clicking on an image.
+
 #### showSaveImage
 
 Type: `boolean`\
@@ -220,6 +227,7 @@ The following options are ignored when `menu` is used:
 - `showLookUpSelection`
 - `showCopyImage`
 - `showCopyImageAddress`
+- `showOpenImageExternally`
 - `showSaveImageAs`
 - `showSaveLinkAs`
 - `showInspectElement`
@@ -240,6 +248,7 @@ Default actions:
 - `saveImageAs`
 - `copyImage`
 - `copyImageAddress`
+- `openImageExternally`
 - `copyLink`
 - `saveLinkAs`
 - `inspect`


### PR DESCRIPTION
If a file is saved locally (e.g. `fixture.jpg`), the `file://` will cause it to open however images are normally open (photo viewer or something). If it's a link to an image (like [Electron_12.0.2_screenshot.png](https://upload.wikimedia.org/wikipedia/commons/b/b2/Electron_12.0.2_screenshot.png) in my testing), it will be displayed in a normal browser window. [It could be useful to add a link to an image in `fixture.js` to test these features as well.]

Suggested in https://github.com/sindresorhus/caprine/issues/1662.