### PR TITLE
Support running with remote

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,9 @@
 'use strict';
-const electron = require('electron');
+const electron = (() => {
+	const electron = require('electron');
+
+	return !!electron.BrowserWindow ? electron : require('@electron/remote');
+})();
 const cliTruncate = require('cli-truncate');
 const {download} = require('electron-dl');
 const isDev = require('electron-is-dev');
@@ -309,10 +313,6 @@ const create = (win, options) => {
 };
 
 module.exports = (options = {}) => {
-	if (process.type === 'renderer') {
-		throw new Error('Cannot use electron-context-menu in the renderer process!');
-	}
-
 	let isDisposed = false;
 	const disposables = [];
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"cli-truncate": "^2.1.0",
 		"electron-dl": "^3.2.1",
 		"electron-is-dev": "^2.0.0",
-		"@electron/remote": "git://github.com/gyteng/remote#e0360cbc6ad5737d43be4886dfd72e496cb7c8c6"
+		"@electron/remote": "^2.0.1"
 	},
 	"devDependencies": {
 		"@types/node": "^15.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "electron-context-menu",
-	"version": "3.1.1",
+	"version": "3.1.2",
 	"description": "Context menu for your Electron app",
 	"license": "MIT",
 	"repository": "sindresorhus/electron-context-menu",
@@ -42,7 +42,8 @@
 	"dependencies": {
 		"cli-truncate": "^2.1.0",
 		"electron-dl": "^3.2.1",
-		"electron-is-dev": "^2.0.0"
+		"electron-is-dev": "^2.0.0",
+		"@electron/remote": "git://github.com/gyteng/remote#e0360cbc6ad5737d43be4886dfd72e496cb7c8c6"
 	},
 	"devDependencies": {
 		"@types/node": "^15.0.1",


### PR DESCRIPTION
This PR uses the `@electron/remote` library to enable running `electron-context-menu` in preload scripts.