### PR TITLE
Fix TypeScript compile error with Electron v17

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,6 @@
 import {
 	BrowserWindow,
 	BrowserView,
-	WebviewTag,
 	ContextMenuParams,
 	MenuItemConstructorOptions,
 	Event as ElectronEvent,
@@ -113,7 +112,7 @@ declare namespace contextMenu {
 		Window or WebView to add the context menu to.
 		When not specified, the context menu will be added to all existing and new windows.
 		*/
-		readonly window?: BrowserWindow | BrowserView | WebviewTag | WebContents;
+		readonly window?: BrowserWindow | BrowserView | Electron.WebviewTag | WebContents;
 
 		/**
 		Should return an array of [menu items](https://electronjs.org/docs/api/menu-item) to be prepended to the context menu.
@@ -123,7 +122,7 @@ declare namespace contextMenu {
 		readonly prepend?: (
 			defaultActions: Actions,
 			parameters: ContextMenuParams,
-			browserWindow: BrowserWindow | BrowserView | WebviewTag | WebContents,
+			browserWindow: BrowserWindow | BrowserView | Electron.WebviewTag | WebContents,
 			event: ElectronEvent
 		) => MenuItemConstructorOptions[];
 
@@ -135,7 +134,7 @@ declare namespace contextMenu {
 		readonly append?: (
 			defaultActions: Actions,
 			parameters: ContextMenuParams,
-			browserWindow: BrowserWindow | BrowserView | WebviewTag | WebContents,
+			browserWindow: BrowserWindow | BrowserView | Electron.WebviewTag | WebContents,
 			event: ElectronEvent
 		) => MenuItemConstructorOptions[];
 
@@ -271,7 +270,7 @@ declare namespace contextMenu {
 		readonly menu?: (
 			defaultActions: Actions,
 			parameters: ContextMenuParams,
-			browserWindow: BrowserWindow | BrowserView | WebviewTag | WebContents,
+			browserWindow: BrowserWindow | BrowserView | Electron.WebviewTag | WebContents,
 			dictionarySuggestions: MenuItemConstructorOptions[],
 			event: ElectronEvent
 		) => MenuItemConstructorOptions[];


### PR DESCRIPTION
## Problem

When I upgraded Electron dependency to the latest version v17, compiling electron-context-menu with TypeScript compiler caused the following error:

```
> tsc -p .

node_modules/electron-context-menu/index.d.ts:4:2 - error TS2305: Module '"electron"' has no exported member 'WebviewTag'.

4  WebviewTag,
   ~~~~~~~~~~


Found 1 error.
```

After some investigation, I realized that `WebviewTag` is no longer defined in `electron` module.

Since the compile error happens in dependency's type definition file, there is no way to fix it from a user. So this is a blocker to upgrade Electron version to the latest for me.

## Fix

Instead of importing it from `electron` module, referring the `WebviewTag` class defined in `Electron` namespace directly worked fine.

---

Fixes #148