### PR TITLE
Optional Learn Spelling just like the others

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -139,6 +139,13 @@ declare namespace contextMenu {
 		) => MenuItemConstructorOptions[];
 
 		/**
+		Show the `Learn Spelling {selection}` menu item when right-clicking text on macOS.
+
+		@default true
+		*/
+		readonly showLearnSpelling?: boolean;
+
+		/**
 		Show the `Look Up {selection}` menu item when right-clicking text on macOS.
 
 		@default true
@@ -254,6 +261,7 @@ declare namespace contextMenu {
 
 		The following options are ignored when `menu` is used:
 
+		- `showLearnSpelling`
 		- `showLookUpSelection`
 		- `showSearchWithGoogle`
 		- `showCopyImage`

--- a/index.js
+++ b/index.js
@@ -231,7 +231,7 @@ const create = (win, options) => {
 			dictionarySuggestions.length > 0 && defaultActions.separator(),
 			...dictionarySuggestions,
 			defaultActions.separator(),
-			defaultActions.learnSpelling(),
+			options.showLearnSpelling !== false && defaultActions.learnSpelling(),
 			defaultActions.separator(),
 			options.showLookUpSelection !== false && defaultActions.lookUpSelection(),
 			defaultActions.separator(),

--- a/readme.md
+++ b/readme.md
@@ -120,19 +120,26 @@ The first argument is an array of default actions that can be used. The second a
 
 `MenuItem` labels may contain the placeholder `{selection}` which will be replaced by the currently selected text as described in [`options.labels`](#labels).
 
+#### showLearnSpelling
+
+Type: `boolean`\
+Default: `true`
+
+Show the `Learn Spelling {selection}` menu item when right-clicking text.
+
 #### showLookUpSelection
 
 Type: `boolean`\
 Default: `true`
 
-Show the `Look Up {selection}` menu item when right-clicking text on macOS.
+Show the `Look Up {selection}` menu item when right-clicking text.
 
 #### showSearchWithGoogle
 
 Type: `boolean`\
 Default: `true`
 
-Show the `Search with Google` menu item when right-clicking text on macOS.
+Show the `Search with Google` menu item when right-clicking text.
 
 #### showCopyImage
 


### PR DESCRIPTION
Added a flag just like for the others as it was missing.

As a mitigation, it can be disabled globally through electron `webPreferences` but that has other effects.