### PR TITLE
Add onShow & onClose callbacks

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -286,7 +286,7 @@ declare namespace contextMenu {
 		) => MenuItemConstructorOptions[];
 
 		/**
-		Called before the context menu instance is created.
+		Called when the context menu is shown.
 		*/
 		readonly onShow?: (event: ElectronEvent) => void;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -284,6 +284,24 @@ declare namespace contextMenu {
 			dictionarySuggestions: MenuItemConstructorOptions[],
 			event: ElectronEvent
 		) => MenuItemConstructorOptions[];
+
+		/**
+		Called before context menu instance is created. Triggered by `menu-will-show` from `Menu` class.
+
+		Official documentation: https://www.electronjs.org/docs/latest/api/menu#event-menu-will-show
+		*/
+		readonly onShow?: (
+			event: ElectronEvent
+		) => void;
+
+		/**
+		Called when context menu is closed. Triggered by `menu-will-close` from `Menu` class.
+
+		Official documentation: https://www.electronjs.org/docs/latest/api/menu#event-menu-will-close
+		*/
+		readonly onClose?: (
+			event: ElectronEvent
+		) => void;
 	}
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -286,9 +286,7 @@ declare namespace contextMenu {
 		) => MenuItemConstructorOptions[];
 
 		/**
-		Called before context menu instance is created. Triggered by `menu-will-show` from `Menu` class.
-
-		Official documentation: https://www.electronjs.org/docs/latest/api/menu#event-menu-will-show
+		Called before context menu instance is created.
 		*/
 		readonly onShow?: (
 			event: ElectronEvent

--- a/index.d.ts
+++ b/index.d.ts
@@ -286,20 +286,14 @@ declare namespace contextMenu {
 		) => MenuItemConstructorOptions[];
 
 		/**
-		Called before context menu instance is created.
+		Called before the context menu instance is created.
 		*/
-		readonly onShow?: (
-			event: ElectronEvent
-		) => void;
+		readonly onShow?: (event: ElectronEvent) => void;
 
 		/**
-		Called when context menu is closed. Triggered by `menu-will-close` from `Menu` class.
-
-		Official documentation: https://www.electronjs.org/docs/latest/api/menu#event-menu-will-close
+		Called when the context menu is closed.
 		*/
-		readonly onClose?: (
-			event: ElectronEvent
-		) => void;
+		readonly onClose?: (event: ElectronEvent) => void;
 	}
 }
 

--- a/index.js
+++ b/index.js
@@ -295,11 +295,11 @@ const create = (win, options) => {
 			const menu = electron.Menu.buildFromTemplate(menuTemplate);
 
 			if (typeof options.onShow === 'function') {
-				menu.on('menu-will-show', options.onShow)
+				menu.on('menu-will-show', options.onShow);
 			}
 
 			if (typeof options.onClose === 'function') {
-				menu.on('menu-will-close', options.onClose)
+				menu.on('menu-will-close', options.onClose);
 			}
 
 			menu.popup(win);

--- a/index.js
+++ b/index.js
@@ -293,6 +293,15 @@ const create = (win, options) => {
 
 		if (menuTemplate.length > 0) {
 			const menu = electron.Menu.buildFromTemplate(menuTemplate);
+
+			if (typeof options.onShow === 'function') {
+				menu.on('menu-will-show', options.onShow)
+			}
+
+			if (typeof options.onClose === 'function') {
+				menu.on('menu-will-close', options.onClose)
+			}
+
 			menu.popup(win);
 		}
 	};

--- a/readme.md
+++ b/readme.md
@@ -309,13 +309,17 @@ Example for actions:
 
 Type: `Function`
 
-Called before context menu instance is created. Triggered by `menu-will-show` from `Menu` class.
+Called before the context menu instance is created.
+
+The function receives an [`Event` object](https://developer.mozilla.org/en-US/docs/Web/API/Event).
 
 #### onClose
 
 Type: `Function`
 
-Called when context menu is closed. Triggered by `menu-will-close` from `Menu` class. Read [official documentation](https://www.electronjs.org/docs/latest/api/menu#event-menu-will-close).
+Called when the context menu is closed.
+
+The function receives an [`Event` object](https://developer.mozilla.org/en-US/docs/Web/API/Event).
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -309,7 +309,7 @@ Example for actions:
 
 Type: `Function`
 
-Called before context menu instance is created. Triggered by `menu-will-show` from `Menu` class. Read [official documentation](https://www.electronjs.org/docs/latest/api/menu#event-menu-will-show).
+Called before context menu instance is created. Triggered by `menu-will-show` from `Menu` class.
 
 #### onClose
 

--- a/readme.md
+++ b/readme.md
@@ -305,6 +305,18 @@ Example for actions:
 }
 ```
 
+#### onShow
+
+Type: `Function`
+
+Called before context menu instance is created. Triggered by `menu-will-show` from `Menu` class. Read [official documentation](https://www.electronjs.org/docs/latest/api/menu#event-menu-will-show).
+
+#### onClose
+
+Type: `Function`
+
+Called when context menu is closed. Triggered by `menu-will-close` from `Menu` class. Read [official documentation](https://www.electronjs.org/docs/latest/api/menu#event-menu-will-close).
+
 ## Related
 
 - [electron-util](https://github.com/sindresorhus/electron-util) - Useful utilities for developing Electron apps and modules

--- a/readme.md
+++ b/readme.md
@@ -309,7 +309,7 @@ Example for actions:
 
 Type: `Function`
 
-Called before the context menu instance is created.
+Called when the context menu is shown.
 
 The function receives an [`Event` object](https://developer.mozilla.org/en-US/docs/Web/API/Event).
 


### PR DESCRIPTION
Add two callbacks `onShow` and `onClose` that are called based on `Menu` class events `menu-will-show` and `menu-will-close`.

In case we need to change UI if context menu is open/closed.