### PR TITLE
Add `Select All` menu item #118

### DIFF
--- a/fixtures/fixture.js
+++ b/fixtures/fixture.js
@@ -9,7 +9,6 @@ contextMenu({
 		copy: 'Configured Copy',
 		paste: 'Configured Paste',
 		save: 'Configured Save Image',
-		selectAll: 'Configured Select All',
 		saveImageAs: 'Configured Save Image As…',
 		copyLink: 'Configured Copy Link',
 		saveLinkAs: 'Configured Save Link As…',
@@ -37,11 +36,11 @@ contextMenu({
 		}
 	],
 	append: () => {},
+	showSelectAll: true,
 	showCopyImageAddress: true,
 	showSaveImageAs: true,
 	showInspectElement: false,
-	showSaveLinkAs: true,
-	showSelectAll: true
+	showSaveLinkAs: true
 });
 
 (async () => {

--- a/fixtures/fixture.js
+++ b/fixtures/fixture.js
@@ -9,6 +9,7 @@ contextMenu({
 		copy: 'Configured Copy',
 		paste: 'Configured Paste',
 		save: 'Configured Save Image',
+		selectAll: 'Configured Select All',
 		saveImageAs: 'Configured Save Image As…',
 		copyLink: 'Configured Copy Link',
 		saveLinkAs: 'Configured Save Link As…',
@@ -39,7 +40,8 @@ contextMenu({
 	showCopyImageAddress: true,
 	showSaveImageAs: true,
 	showInspectElement: false,
-	showSaveLinkAs: true
+	showSaveLinkAs: true,
+	showSelectAll: true
 });
 
 (async () => {

--- a/index.d.ts
+++ b/index.d.ts
@@ -170,7 +170,7 @@ declare namespace contextMenu {
 		/**
 		Show the `Select All` menu item when right-clicking in a window.
 
-		@default true except on macOS
+		Default: `false` on macOS, `true` on Windows and Linux
 		*/
 		readonly showSelectAll?: boolean;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -168,6 +168,13 @@ declare namespace contextMenu {
 		readonly showSearchWithGoogle?: boolean;
 
 		/**
+		Show the `Select All` menu item when right-clicking in a window.
+
+		@default true except on macOS
+		*/
+		readonly showSelectAll?: boolean;
+
+		/**
 		Show the `Copy Image` menu item when right-clicking on an image.
 
 		@default true
@@ -215,13 +222,6 @@ declare namespace contextMenu {
 		@default false
 		*/
 		readonly showServices?: boolean;
-
-		/**
-		Force display/hide the `Select All` menu-item when right-clicking in a window
-
-		@default false for macOS and true for all other OSes
-		*/
-		readonly showSelectAll?: boolean;
 
 		/**
 		Override labels for the default menu items. Useful for i18n.
@@ -279,6 +279,7 @@ declare namespace contextMenu {
 		- `showLearnSpelling`
 		- `showLookUpSelection`
 		- `showSearchWithGoogle`
+		- `showSelectAll`
 		- `showCopyImage`
 		- `showCopyImageAddress`
 		- `showSaveImageAs`
@@ -288,7 +289,7 @@ declare namespace contextMenu {
 
 		To get spellchecking, “Correct Automatically”, and “Learn Spelling” in the menu, please enable the `spellcheck` preference in browser window: `new BrowserWindow({webPreferences: {spellcheck: true}})`
 
-		@default [...dictionarySuggestions, defaultActions.separator(), defaultActions.separator(), defaultActions.learnSpelling(), defaultActions.separator(), defaultActions.lookUpSelection(), defaultActions.separator(),defaultActions.searchWithGoogle(), defaultActions.cut(), defaultActions.copy(), defaultActions.paste(), defaultActions.separator(), defaultActions.saveImage(), defaultActions.saveImageAs(), defaultActions.copyLink(), defaultActions.copyImage(), defaultActions.copyImageAddress(), defaultActions.separator(), defaultActions.copyLink(), defaultActions.saveLinkAs(), defaultActions.separator(), defaultActions.inspect()]
+		@default [...dictionarySuggestions, defaultActions.separator(), defaultActions.separator(), defaultActions.learnSpelling(), defaultActions.separator(), defaultActions.lookUpSelection(), defaultActions.separator(),defaultActions.searchWithGoogle(), defaultActions.cut(), defaultActions.copy(), defaultActions.paste(), defaultActions.selectAll(), defaultActions.separator(), defaultActions.saveImage(), defaultActions.saveImageAs(), defaultActions.copyLink(), defaultActions.copyImage(), defaultActions.copyImageAddress(), defaultActions.separator(), defaultActions.copyLink(), defaultActions.saveLinkAs(), defaultActions.separator(), defaultActions.inspect()]
 		*/
 		readonly menu?: (
 			defaultActions: Actions,

--- a/index.d.ts
+++ b/index.d.ts
@@ -41,6 +41,11 @@ declare namespace contextMenu {
 		readonly paste?: string;
 
 		/**
+		@default 'Select All'
+		*/
+		readonly selectAll?: string;
+
+		/**
 		@default 'Save Image'
 		*/
 		readonly saveImage?: string;
@@ -98,6 +103,7 @@ declare namespace contextMenu {
 		readonly cut: (options: ActionOptions) => MenuItemConstructorOptions;
 		readonly copy: (options: ActionOptions) => MenuItemConstructorOptions;
 		readonly paste: (options: ActionOptions) => MenuItemConstructorOptions;
+		readonly selectAll: (options: ActionOptions) => MenuItemConstructorOptions;
 		readonly saveImage: (options: ActionOptions) => MenuItemConstructorOptions;
 		readonly saveImageAs: (options: ActionOptions) => MenuItemConstructorOptions;
 		readonly copyLink: (options: ActionOptions) => MenuItemConstructorOptions;
@@ -209,6 +215,13 @@ declare namespace contextMenu {
 		@default false
 		*/
 		readonly showServices?: boolean;
+
+		/**
+		Force display/hide the `Select All` menu-item when right-clicking in a window
+
+		@default false for macOS and true for all other OSes
+		*/
+		readonly showSelectAll?: boolean;
 
 		/**
 		Override labels for the default menu items. Useful for i18n.

--- a/index.js
+++ b/index.js
@@ -119,6 +119,13 @@ const create = (win, options) => {
 					}
 				}
 			}),
+			selectAll: decorateMenuItem({
+				id: 'selectAll',
+				label: 'Select &All',
+				click() {
+					webContents(win).selectAll();
+				}
+			}),
 			saveImage: decorateMenuItem({
 				id: 'saveImage',
 				label: 'Save I&mage',
@@ -200,6 +207,7 @@ const create = (win, options) => {
 		};
 
 		const shouldShowInspectElement = typeof options.showInspectElement === 'boolean' ? options.showInspectElement : isDev;
+		const shouldShowSelectAll = options.showSelectAll || (options.showSelectAll !== false && process.platform !== 'darwin');
 
 		function word(suggestion) {
 			return {
@@ -240,6 +248,7 @@ const create = (win, options) => {
 			defaultActions.cut(),
 			defaultActions.copy(),
 			defaultActions.paste(),
+			shouldShowSelectAll && defaultActions.selectAll(),
 			defaultActions.separator(),
 			options.showSaveImage && defaultActions.saveImage(),
 			options.showSaveImageAs && defaultActions.saveImageAs(),

--- a/readme.md
+++ b/readme.md
@@ -143,6 +143,13 @@ Default: `true`
 
 Show the `Search with Google` menu item when right-clicking text.
 
+#### showSelectAll
+
+Type: `boolean`\
+Default: `true` except on macOS
+
+Show the `Select All` menu item when right-clicking in a window.
+
 #### showCopyImage
 
 Type: `boolean`\
@@ -193,13 +200,6 @@ Default: `false`
 Show the system `Services` submenu when right-clicking text on macOS.
 
 Note: Due to [a bug in the Electron implementation](https://github.com/electron/electron/issues/18476), this menu is not identical to the "Services" submenu in the context menus of native apps. Instead, it looks the same as the "Services" menu in the main App Menu. For this reason, it is currently disabled by default.
-
-#### showSelectAll
-
-Type: `boolean`\
-Default: `false` for macOS and `true` for all other OSes
-
-Force display/hide the `Select All` menu-item when right-clicking in a window.
 
 #### labels
 
@@ -256,14 +256,14 @@ To get spellchecking, “Correct Automatically”, and “Learn Spelling” in t
 The following options are ignored when `menu` is used:
 
 - `showLookUpSelection`
+- `showSearchWithGoogle`
+- `showSelectAll`
 - `showCopyImage`
 - `showCopyImageAddress`
 - `showSaveImageAs`
 - `showSaveLinkAs`
 - `showInspectElement`
 - `showServices`
-- `showSearchWithGoogle`
-- `showSelectAll`
 
 Default actions:
 

--- a/readme.md
+++ b/readme.md
@@ -194,6 +194,13 @@ Show the system `Services` submenu when right-clicking text on macOS.
 
 Note: Due to [a bug in the Electron implementation](https://github.com/electron/electron/issues/18476), this menu is not identical to the "Services" submenu in the context menus of native apps. Instead, it looks the same as the "Services" menu in the main App Menu. For this reason, it is currently disabled by default.
 
+#### showSelectAll
+
+Type: `boolean`\
+Default: `false` for macOS and `true` for all other OSes
+
+Force display/hide the `Select All` menu-item when right-clicking in a window.
+
 #### labels
 
 Type: `object`\
@@ -256,6 +263,7 @@ The following options are ignored when `menu` is used:
 - `showInspectElement`
 - `showServices`
 - `showSearchWithGoogle`
+- `showSelectAll`
 
 Default actions:
 
@@ -267,6 +275,7 @@ Default actions:
 - `cut`
 - `copy`
 - `paste`
+- `selectAll`
 - `saveImage`
 - `saveImageAs`
 - `copyImage`

--- a/readme.md
+++ b/readme.md
@@ -146,7 +146,7 @@ Show the `Search with Google` menu item when right-clicking text.
 #### showSelectAll
 
 Type: `boolean`\
-Default: `true` except on macOS
+Default: `false` on macOS, `true` on Windows and Linux
 
 Show the `Select All` menu item when right-clicking in a window.
 


### PR DESCRIPTION
An implementation for [#118 Missing Select All?](https://github.com/sindresorhus/electron-context-menu/issues/118), defaulting to only show if non-macOS (but can be forced to be shown/hidden via the `showSelectAll` option). 

Placing `Select All` below `Paste` to mimic Edit sub-menu in Electron (2nd image) and most other context menus.

<img width="281" alt="Screen Shot 2022-08-09 at 10 20 02 AM" src="https://user-images.githubusercontent.com/13176853/183673404-2c4a23f5-5b47-406c-959c-2a711638de60.png">

<img width="414" alt="Screen Shot 2022-08-09 at 9 59 11 AM" src="https://user-images.githubusercontent.com/13176853/183669153-c62c1b10-17aa-48b0-b9cd-02074d1c8e89.png">


---

Fixes #118