### PR TITLE
add shell import to example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ let mainWindow;
 Advanced example:
 
 ```js
-const {app, BrowserWindow} = require('electron');
+const {app, BrowserWindow, shell} = require('electron');
 const contextMenu = require('electron-context-menu');
 
 contextMenu({


### PR DESCRIPTION
Problem:
Advanced example is not working due to `ReferenceError: shell is not defined`

Solution:
Shell import in a header of an example.