### PR TITLE
Add generic search engine menu item

### DIFF
--- a/fixtures/fixture.js
+++ b/fixtures/fixture.js
@@ -36,10 +36,9 @@ contextMenu({
 		}
 	],
 	append: () => {},
-	addSearchWithOther:
-	{
-		title: 'DuckDuckGo',
-		url: 'https://duckduckgo.com/?q=%s'
+	addSearchWithOther: {
+		title: 'Wolfram Alpha',
+		url: 'https://www.wolframalpha.com/input?i=%s'
 	},
 	showCopyImageAddress: true,
 	showSaveImageAs: true,

--- a/fixtures/fixture.js
+++ b/fixtures/fixture.js
@@ -36,7 +36,11 @@ contextMenu({
 		}
 	],
 	append: () => {},
-	showSelectAll: true,
+	addSearchWithOther:
+	{
+		title: 'DuckDuckGo',
+		url: 'https://duckduckgo.com/?q=%s'
+	},
 	showCopyImageAddress: true,
 	showSaveImageAs: true,
 	showCopyVideoAddress: true,

--- a/index.d.ts
+++ b/index.d.ts
@@ -26,6 +26,12 @@ declare namespace contextMenu {
 		readonly searchWithGoogle?: string;
 
 		/**
+		The placeholder `{searchEngine}` will be replaced by the `title` property of the `addSearchWithOther` option.
+		@default 'Search with {searchEngine}'
+		*/
+		readonly searchWithOther?: string;
+
+		/**
 		@default 'Cut'
 		*/
 		readonly cut?: string;
@@ -115,6 +121,7 @@ declare namespace contextMenu {
 		readonly learnSpelling: (options: ActionOptions) => MenuItemConstructorOptions;
 		readonly lookUpSelection: (options: ActionOptions) => MenuItemConstructorOptions;
 		readonly searchWithGoogle: (options: ActionOptions) => MenuItemConstructorOptions;
+		readonly searchWithOther: (options: ActionOptions) => MenuItemConstructorOptions;
 		readonly cut: (options: ActionOptions) => MenuItemConstructorOptions;
 		readonly copy: (options: ActionOptions) => MenuItemConstructorOptions;
 		readonly paste: (options: ActionOptions) => MenuItemConstructorOptions;
@@ -184,6 +191,34 @@ declare namespace contextMenu {
 		@default true
 		*/
 		readonly showSearchWithGoogle?: boolean;
+
+		/**
+		Add a `Search with {searchEngine}` menu item when right-clicking text.
+
+		This allows the use of a search engine besides Google (e.g., Bing and DuckDuckGo). The `title` and `url` of the desired search engine need to be provided. The `{searchEngine}` placeholder will be replaced by `title`.
+		@property {string} title Title/name of search engine
+		@property {string} url URL of search engine (with query syntax used in Chrome)
+
+		@example
+		```
+		{
+			addSearchWithOther: {
+				title: 'Bing',
+				url: 'https://www.bing.com/search'
+			}
+		};
+		```
+		@example
+		```
+		{
+			addSearchWithOther: {
+				title: 'DuckDuckGo',
+				url: 'https://duckduckgo.com'
+			}
+		};
+		```
+		*/
+		readonly addSearchWithOther?: {title: string; url: string};
 
 		/**
 		Show the `Select All` menu item when right-clicking in a window.
@@ -318,6 +353,7 @@ declare namespace contextMenu {
 		- `showLearnSpelling`
 		- `showLookUpSelection`
 		- `showSearchWithGoogle`
+		- `addSearchWithOther`
 		- `showSelectAll`
 		- `showCopyImage`
 		- `showCopyImageAddress`
@@ -331,7 +367,7 @@ declare namespace contextMenu {
 
 		To get spellchecking, “Correct Automatically”, and “Learn Spelling” in the menu, please enable the `spellcheck` preference in browser window: `new BrowserWindow({webPreferences: {spellcheck: true}})`
 
-		@default [...dictionarySuggestions, defaultActions.separator(), defaultActions.separator(), defaultActions.learnSpelling(), defaultActions.separator(), defaultActions.lookUpSelection(), defaultActions.separator(),defaultActions.searchWithGoogle(), defaultActions.cut(), defaultActions.copy(), defaultActions.paste(), defaultActions.selectAll(), defaultActions.separator(), defaultActions.saveImage(), defaultActions.saveImageAs(), defaultActions.saveVideo(), defaultActions.saveVideoAs(), defaultActions.copyLink(), defaultActions.copyImage(), defaultActions.copyImageAddress(), defaultActions.separator(), defaultActions.copyLink(), defaultActions.saveLinkAs(), defaultActions.separator(), defaultActions.inspect()]
+		@default [...dictionarySuggestions, defaultActions.separator(), defaultActions.separator(), defaultActions.learnSpelling(), defaultActions.separator(), defaultActions.lookUpSelection(), defaultActions.separator(),defaultActions.searchWithGoogle(), defaultActions.searchWithOther(), defaultActions.cut(), defaultActions.copy(), defaultActions.paste(), defaultActions.selectAll(), defaultActions.separator(), defaultActions.saveImage(), defaultActions.saveImageAs(), defaultActions.saveVideo(), defaultActions.saveVideoAs(), defaultActions.copyLink(), defaultActions.copyImage(), defaultActions.copyImageAddress(), defaultActions.separator(), defaultActions.copyLink(), defaultActions.saveLinkAs(), defaultActions.separator(), defaultActions.inspect()]
 		*/
 		readonly menu?: (
 			defaultActions: Actions,

--- a/index.d.ts
+++ b/index.d.ts
@@ -196,26 +196,25 @@ declare namespace contextMenu {
 		Add a `Search with {searchEngine}` menu item when right-clicking text.
 
 		This allows the use of a search engine besides Google (e.g., Bing and DuckDuckGo). The `title` and `url` of the desired search engine need to be provided. The `{searchEngine}` placeholder will be replaced by `title`.
-		@property {string} title Title/name of search engine
-		@property {string} url URL of search engine (with query syntax used in Chrome)
-
-		@example
-		```
-		{
-			addSearchWithOther: {
-				title: 'Bing',
-				url: 'https://www.bing.com/search'
-			}
-		};
-		```
+		@property {string} title - The title/name of the search engine.
+		@property {string} url - The search engine's results [URL with `%s` in place of query](https://support.google.com/chrome/answer/95426#ts&zippy=%2Curl-with-s-in-place-of-query-field) (syntax used in Chrome).
 		@example
 		```
 		{
 			addSearchWithOther: {
 				title: 'DuckDuckGo',
-				url: 'https://duckduckgo.com'
+				url: 'https://duckduckgo.com?q=%s'
 			}
-		};
+		}
+		```
+		@example
+		```
+		{
+			addSearchWithOther: {
+				title: 'Wolfram Alpha',
+				url: 'https://www.wolframalpha.com/input?i=%s'
+			}
+		}
 		```
 		*/
 		readonly addSearchWithOther?: {title: string; url: string};

--- a/index.js
+++ b/index.js
@@ -78,8 +78,8 @@ const create = (win, options) => {
 				label: `Search &with ${addSearchWithOtherHasValues ? options.addSearchWithOther.title : ''}`,
 				visible: hasText,
 				click() {
-					const url = new URL(addSearchWithOtherHasValues ? options.addSearchWithOther.url : '');
-					url.searchParams.set('q', props.selectionText);
+					let url = addSearchWithOtherHasValues ? options.addSearchWithOther.url : '';
+					url = new URL(url.replace('%s', props.selectionText));
 					electron.shell.openExternal(url.toString());
 				}
 			}),

--- a/index.js
+++ b/index.js
@@ -39,6 +39,9 @@ const create = (win, options) => {
 		const isLink = Boolean(props.linkURL);
 		const can = type => editFlags[`can${type}`] && hasText;
 
+		const addSearchWithOtherExists = typeof options.addSearchWithOther !== 'undefined' && 'title' in options.addSearchWithOther && 'url' in options.addSearchWithOther;
+		const addSearchWithOtherHasValues = addSearchWithOtherExists && options.addSearchWithOther.title.trim().length > 0 && options.addSearchWithOther.url.trim().length > 0;
+
 		const defaultActions = {
 			separator: () => ({type: 'separator'}),
 			learnSpelling: decorateMenuItem({
@@ -66,6 +69,16 @@ const create = (win, options) => {
 				visible: hasText,
 				click() {
 					const url = new URL('https://www.google.com/search');
+					url.searchParams.set('q', props.selectionText);
+					electron.shell.openExternal(url.toString());
+				}
+			}),
+			searchWithOther: decorateMenuItem({
+				id: 'searchWithOther',
+				label: `Search &with ${addSearchWithOtherHasValues ? options.addSearchWithOther.title : ''}`,
+				visible: hasText,
+				click() {
+					const url = new URL(addSearchWithOtherHasValues ? options.addSearchWithOther.url : '');
 					url.searchParams.set('q', props.selectionText);
 					electron.shell.openExternal(url.toString());
 				}
@@ -275,6 +288,7 @@ const create = (win, options) => {
 			options.showLookUpSelection !== false && defaultActions.lookUpSelection(),
 			defaultActions.separator(),
 			options.showSearchWithGoogle !== false && defaultActions.searchWithGoogle(),
+			addSearchWithOtherHasValues && defaultActions.searchWithOther(),
 			defaultActions.separator(),
 			defaultActions.cut(),
 			defaultActions.copy(),

--- a/readme.md
+++ b/readme.md
@@ -154,26 +154,26 @@ This allows the use of a search engine besides Google (e.g., Bing and DuckDuckGo
 
 Properties:
 
-`title` - string - Title/name of search engine
+`title` - string - The title/name of the search engine.
 
-`url` - string - URL of search engine (with query syntax used in Chrome)
+`url` - string - The search engine's results [URL with `%s` in place of query](https://support.google.com/chrome/answer/95426#ts&zippy=%2Curl-with-s-in-place-of-query-field) (syntax used in Chrome).
 
 Examples:
 ```js
 {
 	addSearchWithOther: {
-		title: 'Bing',
-		url: 'https://www.bing.com/search'
+		title: 'DuckDuckGo',
+		url: 'https://duckduckgo.com?q=%s'
 	}
-};
+}
 ```
 ```js
 {
 	addSearchWithOther: {
-		title: 'DuckDuckGo',
-		url: 'https://duckduckgo.com'
+		title: 'Wolfram Alpha',
+		url: 'https://www.wolframalpha.com/input?i=%s'
 	}
-};
+}
 ```
 
 #### showSelectAll

--- a/readme.md
+++ b/readme.md
@@ -143,6 +143,39 @@ Default: `true`
 
 Show the `Search with Google` menu item when right-clicking text.
 
+#### addSearchWithOther
+
+Type: `object: {title: string; url: string}`\
+Default: `{}`
+
+Add a `Search with {searchEngine}` menu item when right-clicking text.
+
+This allows the use of a search engine besides Google (e.g., Bing and DuckDuckGo). The `title` and `url` of the desired search engine need to be provided. The `{searchEngine}` placeholder will be replaced by `title`.
+
+Properties:
+
+`title` - string - Title/name of search engine
+
+`url` - string - URL of search engine (with query syntax used in Chrome)
+
+Examples:
+```js
+{
+	addSearchWithOther: {
+		title: 'Bing',
+		url: 'https://www.bing.com/search'
+	}
+};
+```
+```js
+{
+	addSearchWithOther: {
+		title: 'DuckDuckGo',
+		url: 'https://duckduckgo.com'
+	}
+};
+```
+
 #### showSelectAll
 
 Type: `boolean`\
@@ -278,6 +311,7 @@ The following options are ignored when `menu` is used:
 
 - `showLookUpSelection`
 - `showSearchWithGoogle`
+- `addSearchWithOther`
 - `showSelectAll`
 - `showCopyImage`
 - `showCopyImageAddress`
@@ -296,6 +330,7 @@ Default actions:
 - `separator`
 - `lookUpSelection`
 - `searchWithGoogle`
+- `searchWithOther`
 - `cut`
 - `copy`
 - `paste`


### PR DESCRIPTION
Adding an `addSearchWithOther` option that displays a `Search with {searchEngine}` menu item when an object containing the `title` and `url` of a search engine is provided.

Just wanted to mention a few items I wasn't sure about (still relatively new to js):
- Considered creating an interface or typedef for the object `addSearchWithOther` expects but wasn't sure if that'd be "overkill" since a developer has to jump to another section to see the properties needed. I can update to one of those if preferred, though.
- Was on the fence for the option name. I'm willing to change to `showSearchWithOther`, `showOtherSearchEngine`, or anything else. I just wasn't sure if there might be confusion with the others starting with `show...` being booleans (but maybe it's clear enough with the readme and types file?) so for now decided to err on "more clarity" despite looking a bit out of place. 
- Considered doing some validation on the `url` provided but due to the following, it seemed safe to assume that for ~95% of the use cases, the `url` would be "clean" so decided not to but can update, if preferred.
  - the URLs should be from a small set of sites
  - this module is used by developers 
  - the check seems to need a helper function or 3rd party lib (didn't want to unnecessarily clutter the code)

Fixes #155