### PR TITLE
Add option to hide the Copy Link menu item

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -242,6 +242,13 @@ declare namespace contextMenu {
 		readonly showSaveVideoAs?: boolean;
 
 		/**
+		Show the `Copy Link` menu item when right-clicking on a link.
+
+		@default true
+		*/
+		readonly showCopyLink?: boolean;
+
+		/**
 		Show the `Save Link As…` menu item when right-clicking on a link.
 
 		@default false
@@ -325,6 +332,7 @@ declare namespace contextMenu {
 		- `showCopyVideoAddress`
 		- `showSaveVideo`
 		- `showSaveVideoAs`
+		- `showCopyLink`
 		- `showSaveLinkAs`
 		- `showInspectElement`
 		- `showServices`

--- a/index.js
+++ b/index.js
@@ -289,7 +289,7 @@ const create = (win, options) => {
 			options.showSaveVideoAs && defaultActions.saveVideoAs(),
 			options.showCopyVideoAddress && defaultActions.copyVideoAddress(),
 			defaultActions.separator(),
-			defaultActions.copyLink(),
+			options.showCopyLink !== false && defaultActions.copyLink(),
 			options.showSaveLinkAs && defaultActions.saveLinkAs(),
 			defaultActions.separator(),
 			shouldShowInspectElement && defaultActions.inspect(),

--- a/readme.md
+++ b/readme.md
@@ -199,6 +199,13 @@ Default: `false`
 
 Show the `Save Video As…` menu item when right-clicking on a video.
 
+#### showCopyLink
+
+Type: `boolean`\
+Default: `true`
+
+Show the `Copy Link` menu item when right-clicking on a link.
+
 #### showSaveLinkAs
 
 Type: `boolean`\

--- a/readme.md
+++ b/readme.md
@@ -292,6 +292,7 @@ The following options are ignored when `menu` is used:
 - `showCopyVideoAddress`
 - `showSaveVideo`
 - `showSaveVideoAs`
+- `showCopyLink`
 - `showSaveLinkAs`
 - `showInspectElement`
 - `showServices`


### PR DESCRIPTION
This pull request adds an option to hide the "Copy Link" menu item.

One use case for this would be to use `defaultActions.copyLink` with transform in `prepend` or `append`, without needing to replace the entire menu. Which makes it possible to transform `file://` and `localhost` (webpack dev server) links into the equivalent web links. In FreeTube (https://github.com/FreeTubeApp/FreeTube), which is a YouTube client, we could use it to transform the links of video search results into YouTube links.