### PR TITLE
Use untrimmed text to determine if text is present

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ const create = (win, options) => {
 		}
 
 		const {editFlags} = props;
-		const hasText = props.selectionText.trim().length > 0;
+		const hasText = props.selectionText.length > 0;
 		const isLink = Boolean(props.linkURL);
 		const can = type => editFlags[`can${type}`] && hasText;
 


### PR DESCRIPTION
There is no reason why you shouldn't be able to copy a string that just contains spaces. Chrome allows you to do it, so it's expected that is package should as well. 