### PR TITLE
fix: inspect element not working in BrowserView

### DIFF
--- a/index.js
+++ b/index.js
@@ -222,7 +222,7 @@ const create = (win, options) => {
 				id: 'inspect',
 				label: 'I&nspect Element',
 				click() {
-					win.inspectElement(props.x, props.y);
+					webContents(win).inspectElement(props.x, props.y);
 
 					if (webContents(win).isDevToolsOpened()) {
 						webContents(win).devToolsWebContents.focus();


### PR DESCRIPTION
Previously this would throw and crash the process:

```
TypeError: win.inspectElement is not a function
    at click (/Users/contra/Projects/canopy-app/.webpack/main/index.js:19079:10)
    at MenuItem.click (node:electron/js2c/browser_init:73:1906)
    at a._executeCommand (node:electron/js2c/browser_init:81:2453)
```

This change makes it work, since inspectElement is on the webContents in a BrowserView