### PR TITLE
fix readme to explain that spellcheck option is activated by default since Electron 9

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ let mainWindow;
 
 	mainWindow = new BrowserWindow({
 		webPreferences: {
-			spellcheck: true
+			spellcheck: true // enabled by default since electron 9
 		}
 	});
 })();
@@ -68,7 +68,7 @@ let mainWindow;
 
 	mainWindow = new BrowserWindow({
 		webPreferences: {
-			spellcheck: true
+			spellcheck: true // enabled by default since electron 9
 		}
 	});
 })();
@@ -127,7 +127,7 @@ Default: `true`
 
 Show the `Learn Spelling {selection}` menu item when right-clicking text.
 
-Even if `true`, the `spellcheck` preference in browser window must still be enabled. It will also only show when right-clicking misspelled words.
+Even if `true`, the `spellcheck` preference in browser window must still be enabled on Electron 8. For Electron 9 or higher, this is done by default. The spellcheck will also only show when right-clicking misspelled words.
 
 #### showLookUpSelection
 
@@ -279,7 +279,7 @@ Even though you include an action, it will still only be shown/enabled when appr
 
 `MenuItem` labels may contain the placeholder `{selection}` which will be replaced by the currently selected text as described in [`options.labels`](#labels).
 
-To get spellchecking, “Correct Automatically”, and “Learn Spelling” in the menu, please enable the `spellcheck` preference in browser window: `new BrowserWindow({webPreferences: {spellcheck: true}})`
+To get spellchecking, “Correct Automatically”, and “Learn Spelling” in the menu, please enable the `spellcheck` preference in browser window: `new BrowserWindow({webPreferences: {spellcheck: true}})` if you are on Electron 8.
 
 The following options are ignored when `menu` is used:
 

--- a/readme.md
+++ b/readme.md
@@ -30,11 +30,7 @@ let mainWindow;
 (async () => {
 	await app.whenReady();
 
-	mainWindow = new BrowserWindow({
-		webPreferences: {
-			spellcheck: true // enabled by default since electron 9
-		}
-	});
+	mainWindow = new BrowserWindow();
 })();
 ```
 
@@ -66,11 +62,7 @@ let mainWindow;
 (async () => {
 	await app.whenReady();
 
-	mainWindow = new BrowserWindow({
-		webPreferences: {
-			spellcheck: true // enabled by default since electron 9
-		}
-	});
+	mainWindow = new BrowserWindow();
 })();
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -119,7 +119,7 @@ Default: `true`
 
 Show the `Learn Spelling {selection}` menu item when right-clicking text.
 
-Even if `true`, the `spellcheck` preference in browser window must still be enabled on Electron 8. For Electron 9 or higher, this is done by default. The spellcheck will also only show when right-clicking misspelled words.
+The spellcheck will only show when right-clicking misspelled words.
 
 #### showLookUpSelection
 
@@ -271,7 +271,7 @@ Even though you include an action, it will still only be shown/enabled when appr
 
 `MenuItem` labels may contain the placeholder `{selection}` which will be replaced by the currently selected text as described in [`options.labels`](#labels).
 
-To get spellchecking, “Correct Automatically”, and “Learn Spelling” in the menu, please enable the `spellcheck` preference in browser window: `new BrowserWindow({webPreferences: {spellcheck: true}})` if you are on Electron 8.
+To get spellchecking, “Correct Automatically”, and “Learn Spelling” in the menu, make sure you have not disabled the `spellcheck` option (it's `true` by default) in `BrowserWindow`.
 
 The following options are ignored when `menu` is used:
 


### PR DESCRIPTION
According to the [electron documentation](https://www.electronjs.org/docs/latest/tutorial/spellchecker) :

> For Electron 9 and higher the spellchecker is enabled by default. For Electron 8 you need to enable it in webPreferences.