### PR TITLE
fix: object has been destroyed

### DIFF
--- a/index.js
+++ b/index.js
@@ -374,7 +374,6 @@ export default function contextMenu(options = {}) {
 		const disposeMenu = create(win, options);
 
 		const disposable = () => {
-			win.webContents.off('destroyed', disposable);
 			disposeMenu();
 		};
 


### PR DESCRIPTION
https://github.com/sindresorhus/electron-context-menu/pull/182 added some changes in v4.0.2

but in our case, when closing the application there is now an error thrown by the code

A JavaScript error occurred in the main process

Uncaught Exception:
TypeError: Object has been destroyed
at WebContents.disposable (packages/main/dist/index.cjs:11962:12)
at Object.onceWrapper (node:events:634:26)
at WebContents.emit (node:events:519:28)

the related code is:

https://github.com/sindresorhus/electron-context-menu/blob/125230e7a3489fb61eca6364efef90d35a279726/index.js#L377

we can't unsubscribe once it's already destroyed

trying to move the unsubscribe outside of the callback itself (I don't know if it was expected to have a self-reference callback)