### PR TITLE
Fix `WebContentsView` crash on app quit

### DIFF
--- a/index.js
+++ b/index.js
@@ -350,7 +350,7 @@ const create = (win, options) => {
 	webContents(win).on('context-menu', handleContextMenu);
 
 	return () => {
-		if (win?.isDestroyed && win.isDestroyed()) {
+		if (win?.isDestroyed?.()) {
 			return;
 		}
 

--- a/index.js
+++ b/index.js
@@ -350,7 +350,7 @@ const create = (win, options) => {
 	webContents(win).on('context-menu', handleContextMenu);
 
 	return () => {
-		if (win.isDestroyed()) {
+		if (win?.isDestroyed && win.isDestroyed()) {
 			return;
 		}
 


### PR DESCRIPTION
If you do something like this in your Electron app:

```javascript
const someWebView = new WebContentsView()
const ContextMenu = await import('electron-context-menu')
const contextMenu = ContextMenu.default
contextMenu({ window: someWebView })
```

The app will crash when you quit with an error like:

```
A JavaScript error occurred in the main process

Uncaught Exception:
TypeError: win.isDestroyed is not a function
at node_modules/electron-context-menu/index.js:353:11
at WebContents.disposable (node_modules/electron-context-menu/index.js:377:4)
at Object.onceWrapper (node:events:633:26)
at WebContents.emit (node:events:518:28)
```

This PR fixes that error.